### PR TITLE
Feature: Add ftNode device driver to read data from the serial port of wireless receiver

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,5 +18,6 @@ set(YARP_FORCE_DYNAMIC_PLUGINS TRUE)
 # add_subdirectory(amti) # for the force plates, it needs to be checked if installing in a different machine is possible
 add_subdirectory(optoforce)
 add_subdirectory(ATI_Ethernet)
+add_subdirectory(ftNode)
 add_subdirectory(ftShoe)
 add_subdirectory(ftShoeUdpWrapper)

--- a/ftNode/CMakeLists.txt
+++ b/ftNode/CMakeLists.txt
@@ -1,0 +1,26 @@
+#/*
+# * Copyright (C) 2019 iCub Facility
+# * Authors: Yeshasvi Tirupachuri
+# * CopyPolicy: Released under the terms of the LGPLv2.1 or later, see LGPL.TXT
+# */
+
+# Compile the plugin by default
+YARP_PREPARE_PLUGIN(ftnode TYPE yarp::dev::ftnodeDriver
+                           INCLUDE ftnodeDriver.h
+                           DEFAULT ON
+                           CATEGORY device)
+
+if (ENABLE_ftnode)
+
+    yarp_add_plugin(ftnode ftnodeDriver.cpp ftnodeDriver.h)
+
+    include_directories(${YARP_INCLUDE_DIRS} ${CMAKE_CURRENT_SOURCE_DIR})
+    target_link_libraries(ftnode ${YARP_LIBRARIES})
+    yarp_install(TARGETS ftnode
+                 COMPONENT runtime
+                 LIBRARY DESTINATION ${YARP_DYNAMIC_PLUGINS_INSTALL_DIR}
+                 ARCHIVE DESTINATION ${YARP_STATIC_PLUGINS_INSTALL_DIR})
+
+    yarp_install(FILES ftnode.ini DESTINATION ${YARP_PLUGIN_MANIFESTS_INSTALL_DIR})
+
+endif()

--- a/ftNode/conf/ftNode_ftShoeLeft_yarprobotinterface.xml
+++ b/ftNode/conf/ftNode_ftShoeLeft_yarprobotinterface.xml
@@ -5,13 +5,13 @@
     <!--Serial Device-->
     <device type="serialport" name="SerialportDevice">
         <param name="verbose"> 0 </param>
-        <!--<param name="comport"> COM5 </param> -->        <!--  //windows     -->
-        <param name="comport"> /dev/pts/4 </param>   <!--    //linux     -->
+        <param name="comport"> COM2 </param>        <!--  //windows     -->
+        <!--param name="comport">  /dev/ttyACM0 </param-->   <!--    //linux     -->
         <param name="baudrate"> 115200 </param>
         <param name="xonlim"> 0 </param>
         <param name="xofflim"> 0 </param>
         <param name="readmincharacters"> 0 </param>
-        <param name="readtimeoutmsec"> 5 </param>
+        <param name="readtimeoutmsec"> 50 </param>
         <param name="parityenb"> 0 </param>
         <param name="paritymode"> none </param>
         <param name="ctsenb"> 0 </param>
@@ -25,13 +25,19 @@
         <param name="databits"> 8 </param>
         <param name="stopbits"> 1 </param>
         <param name="line_terminator_char1"> 10 </param>
-        <param name="line_terminator_char2">  10 </param>
+        <param name="line_terminator_char2">  13 </param>
     </device>
 
     <!--ftNode Device-->
     <device type="ftnode" name="ftNodeDriver">
         <param name="period">0.01</param>
         <param name="numberOfFTSensors">4</param>
+        <group name="WRENCH_SCALING_FACTOR">
+            <param name="LeftFront">(1262 1421 4289 52 62 19)</param>
+            <param name="LeftRear">(1110 1319 4330 53 62 18)</param>
+            <param name="RightFront">(1206 1447 4361 52 62 19)</param>
+            <param name="RightRear">(1276 1395 4338 59 61 19)</param>
+        </group>
         <action phase="startup" level="5" type="attach">
             <paramlist name="networks">
                 <elem name="ftNodeDriverLabel">SerialportDevice</elem>

--- a/ftNode/conf/ftNode_ftShoeLeft_yarprobotinterface.xml
+++ b/ftNode/conf/ftNode_ftShoeLeft_yarprobotinterface.xml
@@ -1,0 +1,154 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<robot name="ftNode-ftShoe-left" build=0 portprefix="">
+<!--Following the example in https://github.com/robotology/robots-configuration/blob/devel/experimentalSetups/battery/hardware/battery/icubbattery.xml-->
+
+    <!--Serial Device-->
+    <device type="serialport" name="SerialportDevice">
+        <param name="verbose"> 0 </param>
+        <!--<param name="comport"> COM5 </param> -->        <!--  //windows     -->
+        <param name="comport"> /dev/pts/4 </param>   <!--    //linux     -->
+        <param name="baudrate"> 115200 </param>
+        <param name="xonlim"> 0 </param>
+        <param name="xofflim"> 0 </param>
+        <param name="readmincharacters"> 0 </param>
+        <param name="readtimeoutmsec"> 5 </param>
+        <param name="parityenb"> 0 </param>
+        <param name="paritymode"> none </param>
+        <param name="ctsenb"> 0 </param>
+        <param name="rtsenb"> 0 </param>
+        <param name="xinenb"> 0 </param>
+        <param name="xoutenb"> 0 </param>
+        <param name="modem"> 0 </param>
+        <param name="rcvenb"> 0 </param>
+        <param name="dsrenb"> 0 </param>
+        <param name="dtrdisable"> 0 </param>
+        <param name="databits"> 8 </param>
+        <param name="stopbits"> 1 </param>
+        <param name="line_terminator_char1"> 10 </param>
+        <param name="line_terminator_char2">  10 </param>
+    </device>
+
+    <!--ftNode Device-->
+    <device type="ftnode" name="ftNodeDriver">
+        <param name="period">0.01</param>
+        <param name="numberOfFTSensors">4</param>
+        <action phase="startup" level="5" type="attach">
+            <paramlist name="networks">
+                <elem name="ftNodeDriverLabel">SerialportDevice</elem>
+            </paramlist>
+        </action>
+        <action phase="shutdown" level="5" type="detach"/>
+    </device>
+
+    <device type="analogServer" name="ftNodeDriverWrapper">
+        <param name="name">/ftNodeDriverWrapper/wrench:o</param>
+        <param name="period">20</param>
+        <action phase="startup" level="5" type="attach">
+            <paramlist name="networks">
+                <elem name="ftNodeDriverWrapperLabel">ftNodeDriver</elem>
+            </paramlist>
+        </action>
+        <action phase="shutdown" level="5" type="detach" />
+    </device>
+
+    <!-- Second level devices section - ftshoe -->
+    <device name="ftShoe_l" type="ftshoe">
+        <param name="period"> 10 </param>
+        <param name="useFTNodeDriver">true</param>
+        <param name="ftNodeFirstSensorRange">(0 5)</param>
+        <param name="ftNodeSecondSensorRange">(6 11)</param>
+        <param name="name"> /ft/ftShoe_Left/analog:o </param>
+        <!------------------Transformation from Front to Rear---------------------->
+        <!--TRANSLATION-->
+        <!--fts_offset: the origin of Front ft SoR expressed in Rear ft SoR [m]-->
+        <param name="fts_offset">(-0.181101, 0.0, 0.0)</param>
+        <!--ROTATION-->
+        <!--fts_orientation_R: rotation matrix to transform values (expressed w.r.t. the Front ft SoR) into Rear ft SoR, (i.e., Rear_R_Front)-->
+        <param name="fts_orientation_R">( -1.0,  0.0, 0.0,
+                                           0.0, -1.0, 0.0,
+                                           0.0,  0.0, 1.0
+                                        )
+        <!------------Transformation from Rear to final ftShoe Output-------------->
+        </param>
+        <!--ROTATION-->
+        <!--rear_fts_to_out_R: rotation matrix to transform values (expressed w.r.t. the Rear ft SoR) into the final output SoR-->
+        <!--The final output SoR is located at the origin of the Rear ft SoR (no translation) with the following orientation:-->
+        <!--Z pointing up, X pointing forward (along the line that connects the origins of Rear ft SoR and the Front ft SoR) and Y following right-hand convention-->
+        <param name="rear_fts_to_out_R">(
+                                          -1.0, 0.0,  0.0,
+                                           0.0, 1.0,  0.0,
+                                           0.0, 0.0, -1.0
+                                        )
+        </param>
+        <!--inSitu calibration matrices.-->
+        <param name="useInSituCalibration"> false </param>
+        <!--This matrices applies to the calibrated fts signals, than be sure to set to 1 the useCalibration parameter of both devices-->
+        <group name="inSituMatrices">
+            <param name="front_fts"> (
+                                       0.938857303261460  -0.099987001538724  -0.031719474716931   0.934262757200198  -2.081128504120452   1.116222891312317
+                                      -0.008782994221006   0.755393650114154   0.045656043724651  -1.655858713166938  -0.627809636881184  -1.815251879665972
+                                      -0.013675176859862   0.062209239624336   0.991900304766940  -0.285473412550362   0.672237690815685   0.094924727111362
+                                      -0.003522241315859   0.031293495376460   0.005788286130503   0.909299295313223  -0.034622536733099  -0.026646251320573
+                                      -0.029397178956236   0.014719174094312   0.001425795437255  -0.055596915544064   1.100253681658064   0.017844947080158
+                                      -0.003939180755661   0.010569279599475   0.000530902451101  -0.026442188019439   0.021906211171418   1.087258387321892
+                                    )
+            </param>
+            <param name="rear_fts"> (
+                                       0.826424294040360  -0.091357422730653   0.029217798555402   0.413143077503409  -3.003143284075124  -0.734326709982322
+                                      -0.043527467867752   0.945992379875415  -0.013974374847989  -2.158570031731984  -0.364385509664276   0.178660582281101
+                                       0.018456480855675  -0.027680967629762   0.995373889642780  -0.378801203422740   0.405083974855969  -0.399854054343818
+                                      -0.001858452062923   0.028548921877088  -0.001296050687382   0.882390054944027  -0.021267049818161   0.012534000056372
+                                      -0.024912614354884  -0.002610851373780  -0.001454598169520  -0.013007004521544   1.198536139399159   0.056633344983102
+                                      -0.001526052208884  -0.008395096178476  -0.000888111548024   0.027328873291096  -0.022322328373427   0.963011521138837
+                                    )
+            </param>
+        </group>
+        <action phase="startup" level="5" type="attach">
+            <paramlist name="networks">
+                <elem name="ftshoe_l_ftnodedriver"> ftNodeDriver </elem>
+            </paramlist>
+        </action>
+        <action phase="shutdown" level="5" type="detach"/>
+    </device>
+
+    <!-- Analog wrappers sections, required to forward devices data on dedicated yarp ports -->
+    <!-- Analog wrappers sections - ftshoe devices wrappers -->
+    <device name="ftSensWrapper" type="analogServer">
+        <param name="period"> 10 </param>
+        <param name="name"> /ft/ftShoe_Left/analog:o </param>
+        <action phase="startup" level="5" type="attach">
+            <paramlist name="networks">
+                <elem name="FirstStrain"> ftShoe_l </elem>
+            </paramlist>
+        </action>
+        <action phase="shutdown" level="5" type="detach"/>
+    </device>
+
+    <device type="ianalogsensor_to_iwear" name="FTShoeLeftIAnalogSensorToIWear">
+        <param name="sensorName">FTShoeLeftFTSensors</param>
+        <param name="wearableName">FTShoeLeft</param>
+        <param name="numberOfChannels">6</param>
+        <param name="channelOffset">0</param>
+        <param name="wearableSensorType">ForceTorque6DSensor</param>
+        <param name="getGroundReactionFT">true</param>
+        <action phase="startup" level="5" type="attach">
+            <paramlist name="networks">
+                <elem name="FTShoeLeftIAnalogSensorToIWearLabel">ftShoe_l</elem>
+            </paramlist>
+        </action>
+        <action phase="shutdown" level="5" type="detach"/>
+    </device>
+
+    <device type="iwear_wrapper" name="FTShoeLeftIWearWrapper">
+        <param name="period">0.01</param>
+        <param name="dataPortName">/FTShoeLeft/WearableData/data:o</param>
+        <param name="rpcPortName">/FTShoeLeft/WearableData/metadataRpc:o</param>
+        <action phase="startup" level="5" type="attach">
+            <paramlist name="networks">
+                <elem name="FTShoeLeftIWearWrapperLabel">FTShoeLeftIAnalogSensorToIWear</elem>
+            </paramlist>
+        </action>
+        <action phase="shutdown" level="5" type="detach"/>
+    </device>
+
+</robot>

--- a/ftNode/conf/ftNode_ftShoeRight_yarprobotinterface.xml
+++ b/ftNode/conf/ftNode_ftShoeRight_yarprobotinterface.xml
@@ -1,0 +1,155 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<robot name="ftNode-ftShoe-right" build=0 portprefix="">
+<!--Following the example in https://github.com/robotology/robots-configuration/blob/devel/experimentalSetups/battery/hardware/battery/icubbattery.xml-->
+
+    <!--Serial Device-->
+    <device type="serialport" name="SerialportDevice">
+        <param name="verbose"> 0 </param>
+        <!--<param name="comport"> COM5 </param> -->        <!--  //windows     -->
+        <param name="comport"> /dev/pts/4 </param>   <!--    //linux     -->
+        <param name="baudrate"> 115200 </param>
+        <param name="xonlim"> 0 </param>
+        <param name="xofflim"> 0 </param>
+        <param name="readmincharacters"> 0 </param>
+        <param name="readtimeoutmsec"> 5 </param>
+        <param name="parityenb"> 0 </param>
+        <param name="paritymode"> none </param>
+        <param name="ctsenb"> 0 </param>
+        <param name="rtsenb"> 0 </param>
+        <param name="xinenb"> 0 </param>
+        <param name="xoutenb"> 0 </param>
+        <param name="modem"> 0 </param>
+        <param name="rcvenb"> 0 </param>
+        <param name="dsrenb"> 0 </param>
+        <param name="dtrdisable"> 0 </param>
+        <param name="databits"> 8 </param>
+        <param name="stopbits"> 1 </param>
+        <param name="line_terminator_char1"> 10 </param>
+        <param name="line_terminator_char2">  10 </param>
+    </device>
+
+    <!--ftNode Device-->
+    <device type="ftnode" name="ftNodeDriver">
+        <param name="period">0.01</param>
+        <param name="numberOfFTSensors">4</param>
+        <action phase="startup" level="5" type="attach">
+            <paramlist name="networks">
+                <elem name="ftNodeDriverLabel">SerialportDevice</elem>
+            </paramlist>
+        </action>
+        <action phase="shutdown" level="5" type="detach"/>
+    </device>
+
+    <device type="analogServer" name="ftNodeDriverWrapper">
+        <param name="name">/ftNodeDriverWrapper/wrench:o</param>
+        <param name="period">20</param>
+        <action phase="startup" level="5" type="attach">
+            <paramlist name="networks">
+                <elem name="ftNodeDriverWrapperLabel">ftNodeDriver</elem>
+            </paramlist>
+        </action>
+        <action phase="shutdown" level="5" type="detach" />
+    </device>
+
+    <!-- Second level devices section - ftshoe -->
+    <device name="ftShoe_r" type="ftshoe">
+        <param name="period"> 10 </param>
+        <param name="useFTNodeDriver">true</param>
+        <param name="ftNodeFirstSensorRange">(12 17)</param>
+        <param name="ftNodeSecondSensorRange">(18 23)</param>
+        <param name="name"> /ft/ftShoe_Right/analog:o </param>
+        <!------------------Transformation from Front to Rear---------------------->
+        <!--TRANSLATION-->
+        <!--fts_offset: the origin of Front ft SoR expressed in Rear ft SoR [m]-->
+        <param name="fts_offset">(-0.181101, 0.0, 0.0)</param>
+        <!--ROTATION-->
+        <!--fts_orientation_R: rotation matrix to transform values (expressed w.r.t. the Front ft SoR) into Rear ft SoR, (i.e., Rear_R_Front)-->
+        <param name="fts_orientation_R">( -1.0,  0.0, 0.0,
+                                           0.0, -1.0, 0.0,
+                                           0.0,  0.0, 1.0
+                                        )
+        <!------------Transformation from Rear to final ftShoe Output-------------->
+        </param>
+        <!--ROTATION-->
+        <!--rear_fts_to_out_R: rotation matrix to transform values (expressed w.r.t. the Rear ft SoR) into the final output SoR-->
+        <!--The final output SoR is located at the origin of the Rear ft SoR (no translation) with the following orientation:-->
+        <!--Z pointing up, X pointing forward (along the line that connects the origins of Rear ft SoR and the Front ft SoR) and Y following right-hand convention-->
+        <param name="rear_fts_to_out_R">(
+                                          -1.0, 0.0,  0.0,
+                                           0.0, 1.0,  0.0,
+                                           0.0, 0.0, -1.0
+                                        )
+        </param>
+        <!--inSitu calibration matrices.-->
+        <param name="useInSituCalibration"> false </param>
+        <!--This matrices applies to the calibrated fts signals, than be sure to set to 1 the useCalibration parameter of both devices-->
+        <group name="inSituMatrices">
+            <param name="front_fts"> (
+                                       0.927495744506558   0.041016654619440  -0.020768066468872  -0.686739129220131  -1.700341714921413  -0.655844186466448
+                                       0.032691498454271   0.905387122196879  -0.062060254943741  -2.528433638522609   1.936698940397620  -1.261426627647161
+                                       0.030307518024746  -0.042708402432872   0.990834772663811  -0.771255812731485   1.379976452711553   1.338383628433477
+                                       0.003417328018857   0.027192538668070   0.000903874352365   0.934072112166630   0.018298809861597   0.009727347237814
+                                      -0.029683885285561  -0.009657076123040  -0.001319794460849   0.070540847374860   1.112394249787454  -0.081039701093926
+                                      -0.003720738063755   0.002403350518587  -0.001256203878104  -0.004909951055368   0.004652419860706   1.023620297977032
+                                    )
+            </param>
+            <param name="rear_fts"> (
+                                       0.752606509808956   0.128485214807810   0.037816833951859  -1.189506447082422  -3.528696946955530   0.367956429295563
+                                       0.032994788492599   0.947861991843522   0.014131047867024  -2.503874602191483  -0.306564401641517   0.033900728916422
+                                       0.010291417081055  -0.016786848400983   0.997235043288604   0.044337750405427   0.628784109489714   0.608479361767708
+                                      -0.000534324857619   0.039993343127271  -0.000046443326033   0.846610774589901  -0.114938934447660  -0.164828223499561
+                                      -0.021558854024374   0.008200634539163  -0.003084470512841   0.036116559584761   1.220596115437195  -0.067513275649460
+                                      -0.000434930362439   0.001589856391163  -0.000514737521434  -0.009663262776501   0.025349107573698   1.107985249217049
+                                    )
+            </param>
+        </group>
+        <action phase="startup" level="5" type="attach">
+            <paramlist name="networks">
+                <elem name="front_ft"> ftShoe_Right_Front </elem>
+                <elem name="rear_ft"> ftShoe_Right_Rear </elem>
+            </paramlist>
+        </action>
+        <action phase="shutdown" level="5" type="detach"/>
+    </device>
+
+    <!-- Analog wrappers sections, required to forward devices data on dedicated yarp ports -->
+    <!-- Analog wrappers sections - ftshoe devices wrappers -->
+    <device name="ftSensWrapper" type="analogServer">
+        <param name="period"> 10 </param>
+        <param name="name"> /ft/ftShoe_Right/analog:o </param>
+        <action phase="startup" level="5" type="attach">
+            <paramlist name="networks">
+                <elem name="FirstStrain"> ftShoe_r </elem>
+            </paramlist>
+        </action>
+        <action phase="shutdown" level="5" type="detach"/>
+    </device>
+
+    <device type="ianalogsensor_to_iwear" name="FTShoeRightIAnalogSensorToIWear">
+        <param name="sensorName">FTShoeRightFTSensors</param>
+        <param name="wearableName">FTShoeRight</param>
+        <param name="numberOfChannels">6</param>
+        <param name="channelOffset">0</param>
+        <param name="wearableSensorType">ForceTorque6DSensor</param>
+        <param name="getGroundReactionFT">true</param>
+        <action phase="startup" level="5" type="attach">
+            <paramlist name="networks">
+                <elem name="FTShoeRightIAnalogSensorToIWearLabel">ftShoe_r</elem>
+            </paramlist>
+        </action>
+        <action phase="shutdown" level="5" type="detach"/>
+    </device>
+
+    <device type="iwear_wrapper" name="FTShoeRightIWearWrapper">
+        <param name="period">0.01</param>
+        <param name="dataPortName">/FTShoeRight/WearableData/data:o</param>
+        <param name="rpcPortName">/FTShoeRight/WearableData/metadataRpc:o</param>
+        <action phase="startup" level="5" type="attach">
+            <paramlist name="networks">
+                <elem name="FTShoeRightIWearWrapperLabel">FTShoeRightIAnalogSensorToIWear</elem>
+            </paramlist>
+        </action>
+        <action phase="shutdown" level="5" type="detach"/>
+    </device>
+
+</robot>

--- a/ftNode/conf/ftNode_ftShoeRight_yarprobotinterface.xml
+++ b/ftNode/conf/ftNode_ftShoeRight_yarprobotinterface.xml
@@ -5,13 +5,13 @@
     <!--Serial Device-->
     <device type="serialport" name="SerialportDevice">
         <param name="verbose"> 0 </param>
-        <!--<param name="comport"> COM5 </param> -->        <!--  //windows     -->
-        <param name="comport"> /dev/pts/4 </param>   <!--    //linux     -->
+        <param name="comport"> COM2 </param>        <!--  //windows     -->
+        <!--param name="comport">  /dev/ttyACM0 </param-->   <!--    //linux     -->
         <param name="baudrate"> 115200 </param>
         <param name="xonlim"> 0 </param>
         <param name="xofflim"> 0 </param>
         <param name="readmincharacters"> 0 </param>
-        <param name="readtimeoutmsec"> 5 </param>
+        <param name="readtimeoutmsec"> 50 </param>
         <param name="parityenb"> 0 </param>
         <param name="paritymode"> none </param>
         <param name="ctsenb"> 0 </param>
@@ -25,13 +25,19 @@
         <param name="databits"> 8 </param>
         <param name="stopbits"> 1 </param>
         <param name="line_terminator_char1"> 10 </param>
-        <param name="line_terminator_char2">  10 </param>
+        <param name="line_terminator_char2">  13 </param>
     </device>
 
     <!--ftNode Device-->
     <device type="ftnode" name="ftNodeDriver">
         <param name="period">0.01</param>
         <param name="numberOfFTSensors">4</param>
+        <group name="WRENCH_SCALING_FACTOR">
+            <param name="LeftFront">(1262 1421 4289 52 62 19)</param>
+            <param name="LeftRear">(1110 1319 4330 53 62 18)</param>
+            <param name="RightFront">(1206 1447 4361 52 62 19)</param>
+            <param name="RightRear">(1276 1395 4338 59 61 19)</param>
+        </group>
         <action phase="startup" level="5" type="attach">
             <paramlist name="networks">
                 <elem name="ftNodeDriverLabel">SerialportDevice</elem>
@@ -105,8 +111,7 @@
         </group>
         <action phase="startup" level="5" type="attach">
             <paramlist name="networks">
-                <elem name="front_ft"> ftShoe_Right_Front </elem>
-                <elem name="rear_ft"> ftShoe_Right_Rear </elem>
+                <elem name="ftshoe_r_ftnodedriver"> ftNodeDriver </elem>
             </paramlist>
         </action>
         <action phase="shutdown" level="5" type="detach"/>

--- a/ftNode/conf/ftNode_ftShoe_yarprobotinterface.xml
+++ b/ftNode/conf/ftNode_ftShoe_yarprobotinterface.xml
@@ -1,0 +1,260 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<robot name="ftNode-ftShoe" build=0 portprefix="">
+<!--Following the example in https://github.com/robotology/robots-configuration/blob/devel/experimentalSetups/battery/hardware/battery/icubbattery.xml-->
+
+    <!--Serial Device-->
+    <device type="serialport" name="SerialportDevice">
+        <param name="verbose"> 0 </param>
+        <param name="comport"> COM2 </param>        <!--  //windows     -->
+        <!--param name="comport">  /dev/ttyACM0 </param-->   <!--    //linux     -->
+        <param name="baudrate"> 115200 </param>
+        <param name="xonlim"> 0 </param>
+        <param name="xofflim"> 0 </param>
+        <param name="readmincharacters"> 0 </param>
+        <param name="readtimeoutmsec"> 50 </param>
+        <param name="parityenb"> 0 </param>
+        <param name="paritymode"> none </param>
+        <param name="ctsenb"> 0 </param>
+        <param name="rtsenb"> 0 </param>
+        <param name="xinenb"> 0 </param>
+        <param name="xoutenb"> 0 </param>
+        <param name="modem"> 0 </param>
+        <param name="rcvenb"> 0 </param>
+        <param name="dsrenb"> 0 </param>
+        <param name="dtrdisable"> 0 </param>
+        <param name="databits"> 8 </param>
+        <param name="stopbits"> 1 </param>
+        <param name="line_terminator_char1"> 10 </param>
+        <param name="line_terminator_char2">  13 </param>
+    </device>
+
+    <!--ftNode Device-->
+    <device type="ftnode" name="ftNodeDriver">
+        <param name="period">0.01</param>
+        <param name="numberOfFTSensors">4</param>
+        <group name="WRENCH_SCALING_FACTOR">
+            <param name="LeftFront">(1262 1421 4289 52 62 19)</param>
+            <param name="LeftRear">(1110 1319 4330 53 62 18)</param>
+            <param name="RightFront">(1206 1447 4361 52 62 19)</param>
+            <param name="RightRear">(1276 1395 4338 59 61 19)</param>
+        </group>
+        <action phase="startup" level="5" type="attach">
+            <paramlist name="networks">
+                <elem name="ftNodeDriverLabel">SerialportDevice</elem>
+            </paramlist>
+        </action>
+        <action phase="shutdown" level="5" type="detach"/>
+    </device>
+
+    <device type="analogServer" name="ftNodeDriverWrapper">
+        <param name="name">/ftNodeDriverWrapper/wrench:o</param>
+        <param name="period">20</param>
+        <action phase="startup" level="5" type="attach">
+            <paramlist name="networks">
+                <elem name="ftNodeDriverWrapperLabel">ftNodeDriver</elem>
+            </paramlist>
+        </action>
+        <action phase="shutdown" level="5" type="detach" />
+    </device>
+
+    <!-- Second level devices section - ftshoe -->
+    <device name="ftShoe_l" type="ftshoe">
+        <param name="period"> 10 </param>
+        <param name="useFTNodeDriver">true</param>
+        <param name="ftNodeFirstSensorRange">(0 5)</param>
+        <param name="ftNodeSecondSensorRange">(6 11)</param>
+        <param name="name"> /ft/ftShoe_Left/analog:o </param>
+        <!------------------Transformation from Front to Rear---------------------->
+        <!--TRANSLATION-->
+        <!--fts_offset: the origin of Front ft SoR expressed in Rear ft SoR [m]-->
+        <param name="fts_offset">(-0.181101, 0.0, 0.0)</param>
+        <!--ROTATION-->
+        <!--fts_orientation_R: rotation matrix to transform values (expressed w.r.t. the Front ft SoR) into Rear ft SoR, (i.e., Rear_R_Front)-->
+        <param name="fts_orientation_R">( -1.0,  0.0, 0.0,
+                                           0.0, -1.0, 0.0,
+                                           0.0,  0.0, 1.0
+                                        )
+        <!------------Transformation from Rear to final ftShoe Output-------------->
+        </param>
+        <!--ROTATION-->
+        <!--rear_fts_to_out_R: rotation matrix to transform values (expressed w.r.t. the Rear ft SoR) into the final output SoR-->
+        <!--The final output SoR is located at the origin of the Rear ft SoR (no translation) with the following orientation:-->
+        <!--Z pointing up, X pointing forward (along the line that connects the origins of Rear ft SoR and the Front ft SoR) and Y following right-hand convention-->
+        <param name="rear_fts_to_out_R">(
+                                          -1.0, 0.0,  0.0,
+                                           0.0, 1.0,  0.0,
+                                           0.0, 0.0, -1.0
+                                        )
+        </param>
+        <!--inSitu calibration matrices.-->
+        <param name="useInSituCalibration"> false </param>
+        <!--This matrices applies to the calibrated fts signals, than be sure to set to 1 the useCalibration parameter of both devices-->
+        <group name="inSituMatrices">
+            <param name="front_fts"> (
+                                       0.938857303261460  -0.099987001538724  -0.031719474716931   0.934262757200198  -2.081128504120452   1.116222891312317
+                                      -0.008782994221006   0.755393650114154   0.045656043724651  -1.655858713166938  -0.627809636881184  -1.815251879665972
+                                      -0.013675176859862   0.062209239624336   0.991900304766940  -0.285473412550362   0.672237690815685   0.094924727111362
+                                      -0.003522241315859   0.031293495376460   0.005788286130503   0.909299295313223  -0.034622536733099  -0.026646251320573
+                                      -0.029397178956236   0.014719174094312   0.001425795437255  -0.055596915544064   1.100253681658064   0.017844947080158
+                                      -0.003939180755661   0.010569279599475   0.000530902451101  -0.026442188019439   0.021906211171418   1.087258387321892
+                                    )
+            </param>
+            <param name="rear_fts"> (
+                                       0.826424294040360  -0.091357422730653   0.029217798555402   0.413143077503409  -3.003143284075124  -0.734326709982322
+                                      -0.043527467867752   0.945992379875415  -0.013974374847989  -2.158570031731984  -0.364385509664276   0.178660582281101
+                                       0.018456480855675  -0.027680967629762   0.995373889642780  -0.378801203422740   0.405083974855969  -0.399854054343818
+                                      -0.001858452062923   0.028548921877088  -0.001296050687382   0.882390054944027  -0.021267049818161   0.012534000056372
+                                      -0.024912614354884  -0.002610851373780  -0.001454598169520  -0.013007004521544   1.198536139399159   0.056633344983102
+                                      -0.001526052208884  -0.008395096178476  -0.000888111548024   0.027328873291096  -0.022322328373427   0.963011521138837
+                                    )
+            </param>
+        </group>
+        <action phase="startup" level="5" type="attach">
+            <paramlist name="networks">
+                <elem name="ftshoe_l_ftnodedriver"> ftNodeDriver </elem>
+            </paramlist>
+        </action>
+        <action phase="shutdown" level="5" type="detach"/>
+    </device>
+
+    <!-- Analog wrappers sections, required to forward devices data on dedicated yarp ports -->
+    <!-- Analog wrappers sections - ftshoe devices wrappers -->
+    <device name="ftSensWrapper" type="analogServer">
+        <param name="period"> 10 </param>
+        <param name="name"> /ft/ftShoe_Left/analog:o </param>
+        <action phase="startup" level="5" type="attach">
+            <paramlist name="networks">
+                <elem name="FirstStrain"> ftShoe_l </elem>
+            </paramlist>
+        </action>
+        <action phase="shutdown" level="5" type="detach"/>
+    </device>
+
+    <!--device type="ianalogsensor_to_iwear" name="FTShoeLeftIAnalogSensorToIWear">
+        <param name="sensorName">FTShoeLeftFTSensors</param>
+        <param name="wearableName">FTShoeLeft</param>
+        <param name="numberOfChannels">6</param>
+        <param name="channelOffset">0</param>
+        <param name="wearableSensorType">ForceTorque6DSensor</param>
+        <param name="getGroundReactionFT">true</param>
+        <action phase="startup" level="5" type="attach">
+            <paramlist name="networks">
+                <elem name="FTShoeLeftIAnalogSensorToIWearLabel">ftShoe_l</elem>
+            </paramlist>
+        </action>
+        <action phase="shutdown" level="5" type="detach"/>
+    </device>
+
+    <device type="iwear_wrapper" name="FTShoeLeftIWearWrapper">
+        <param name="period">0.01</param>
+        <param name="dataPortName">/FTShoeLeft/WearableData/data:o</param>
+        <param name="rpcPortName">/FTShoeLeft/WearableData/metadataRpc:o</param>
+        <action phase="startup" level="5" type="attach">
+            <paramlist name="networks">
+                <elem name="FTShoeLeftIWearWrapperLabel">FTShoeLeftIAnalogSensorToIWear</elem>
+            </paramlist>
+        </action>
+        <action phase="shutdown" level="5" type="detach"/>
+    </device-->
+
+    <!-- Second level devices section - ftshoe -->
+    <device name="ftShoe_r" type="ftshoe">
+        <param name="period"> 10 </param>
+        <param name="useFTNodeDriver">true</param>
+        <param name="ftNodeFirstSensorRange">(12 17)</param>
+        <param name="ftNodeSecondSensorRange">(18 23)</param>
+        <param name="name"> /ft/ftShoe_Right/analog:o </param>
+        <!------------------Transformation from Front to Rear---------------------->
+        <!--TRANSLATION-->
+        <!--fts_offset: the origin of Front ft SoR expressed in Rear ft SoR [m]-->
+        <param name="fts_offset">(-0.181101, 0.0, 0.0)</param>
+        <!--ROTATION-->
+        <!--fts_orientation_R: rotation matrix to transform values (expressed w.r.t. the Front ft SoR) into Rear ft SoR, (i.e., Rear_R_Front)-->
+        <param name="fts_orientation_R">( -1.0,  0.0, 0.0,
+                                           0.0, -1.0, 0.0,
+                                           0.0,  0.0, 1.0
+                                        )
+        <!------------Transformation from Rear to final ftShoe Output-------------->
+        </param>
+        <!--ROTATION-->
+        <!--rear_fts_to_out_R: rotation matrix to transform values (expressed w.r.t. the Rear ft SoR) into the final output SoR-->
+        <!--The final output SoR is located at the origin of the Rear ft SoR (no translation) with the following orientation:-->
+        <!--Z pointing up, X pointing forward (along the line that connects the origins of Rear ft SoR and the Front ft SoR) and Y following right-hand convention-->
+        <param name="rear_fts_to_out_R">(
+                                          -1.0, 0.0,  0.0,
+                                           0.0, 1.0,  0.0,
+                                           0.0, 0.0, -1.0
+                                        )
+        </param>
+        <!--inSitu calibration matrices.-->
+        <param name="useInSituCalibration"> false </param>
+        <!--This matrices applies to the calibrated fts signals, than be sure to set to 1 the useCalibration parameter of both devices-->
+        <group name="inSituMatrices">
+            <param name="front_fts"> (
+                                       0.927495744506558   0.041016654619440  -0.020768066468872  -0.686739129220131  -1.700341714921413  -0.655844186466448
+                                       0.032691498454271   0.905387122196879  -0.062060254943741  -2.528433638522609   1.936698940397620  -1.261426627647161
+                                       0.030307518024746  -0.042708402432872   0.990834772663811  -0.771255812731485   1.379976452711553   1.338383628433477
+                                       0.003417328018857   0.027192538668070   0.000903874352365   0.934072112166630   0.018298809861597   0.009727347237814
+                                      -0.029683885285561  -0.009657076123040  -0.001319794460849   0.070540847374860   1.112394249787454  -0.081039701093926
+                                      -0.003720738063755   0.002403350518587  -0.001256203878104  -0.004909951055368   0.004652419860706   1.023620297977032
+                                    )
+            </param>
+            <param name="rear_fts"> (
+                                       0.752606509808956   0.128485214807810   0.037816833951859  -1.189506447082422  -3.528696946955530   0.367956429295563
+                                       0.032994788492599   0.947861991843522   0.014131047867024  -2.503874602191483  -0.306564401641517   0.033900728916422
+                                       0.010291417081055  -0.016786848400983   0.997235043288604   0.044337750405427   0.628784109489714   0.608479361767708
+                                      -0.000534324857619   0.039993343127271  -0.000046443326033   0.846610774589901  -0.114938934447660  -0.164828223499561
+                                      -0.021558854024374   0.008200634539163  -0.003084470512841   0.036116559584761   1.220596115437195  -0.067513275649460
+                                      -0.000434930362439   0.001589856391163  -0.000514737521434  -0.009663262776501   0.025349107573698   1.107985249217049
+                                    )
+            </param>
+        </group>
+        <action phase="startup" level="5" type="attach">
+            <paramlist name="networks">
+                <elem name="ftshoe_r_ftnodedriver"> ftNodeDriver </elem>
+            </paramlist>
+        </action>
+        <action phase="shutdown" level="5" type="detach"/>
+    </device>
+
+    <!-- Analog wrappers sections, required to forward devices data on dedicated yarp ports -->
+    <!-- Analog wrappers sections - ftshoe devices wrappers -->
+    <device name="ftSensWrapper" type="analogServer">
+        <param name="period"> 10 </param>
+        <param name="name"> /ft/ftShoe_Right/analog:o </param>
+        <action phase="startup" level="5" type="attach">
+            <paramlist name="networks">
+                <elem name="FirstStrain"> ftShoe_r </elem>
+            </paramlist>
+        </action>
+        <action phase="shutdown" level="5" type="detach"/>
+    </device>
+
+    <!--device type="ianalogsensor_to_iwear" name="FTShoeRightIAnalogSensorToIWear">
+        <param name="sensorName">FTShoeRightFTSensors</param>
+        <param name="wearableName">FTShoeRight</param>
+        <param name="numberOfChannels">6</param>
+        <param name="channelOffset">0</param>
+        <param name="wearableSensorType">ForceTorque6DSensor</param>
+        <param name="getGroundReactionFT">true</param>
+        <action phase="startup" level="5" type="attach">
+            <paramlist name="networks">
+                <elem name="FTShoeRightIAnalogSensorToIWearLabel">ftShoe_r</elem>
+            </paramlist>
+        </action>
+        <action phase="shutdown" level="5" type="detach"/>
+    </device>
+
+    <device type="iwear_wrapper" name="FTShoeRightIWearWrapper">
+        <param name="period">0.01</param>
+        <param name="dataPortName">/FTShoeRight/WearableData/data:o</param>
+        <param name="rpcPortName">/FTShoeRight/WearableData/metadataRpc:o</param>
+        <action phase="startup" level="5" type="attach">
+            <paramlist name="networks">
+                <elem name="FTShoeRightIWearWrapperLabel">FTShoeRightIAnalogSensorToIWear</elem>
+            </paramlist>
+        </action>
+        <action phase="shutdown" level="5" type="detach"/>
+    </device-->
+
+</robot>

--- a/ftNode/conf/ftNode_ftShoe_yarprobotinterface.xml
+++ b/ftNode/conf/ftNode_ftShoe_yarprobotinterface.xml
@@ -130,7 +130,7 @@
         <action phase="shutdown" level="5" type="detach"/>
     </device>
 
-    <!--device type="ianalogsensor_to_iwear" name="FTShoeLeftIAnalogSensorToIWear">
+    <device type="ianalogsensor_to_iwear" name="FTShoeLeftIAnalogSensorToIWear">
         <param name="sensorName">FTShoeLeftFTSensors</param>
         <param name="wearableName">FTShoeLeft</param>
         <param name="numberOfChannels">6</param>
@@ -155,7 +155,7 @@
             </paramlist>
         </action>
         <action phase="shutdown" level="5" type="detach"/>
-    </device-->
+    </device>
 
     <!-- Second level devices section - ftshoe -->
     <device name="ftShoe_r" type="ftshoe">
@@ -230,7 +230,7 @@
         <action phase="shutdown" level="5" type="detach"/>
     </device>
 
-    <!--device type="ianalogsensor_to_iwear" name="FTShoeRightIAnalogSensorToIWear">
+    <device type="ianalogsensor_to_iwear" name="FTShoeRightIAnalogSensorToIWear">
         <param name="sensorName">FTShoeRightFTSensors</param>
         <param name="wearableName">FTShoeRight</param>
         <param name="numberOfChannels">6</param>
@@ -255,6 +255,6 @@
             </paramlist>
         </action>
         <action phase="shutdown" level="5" type="detach"/>
-    </device-->
+    </device>
 
 </robot>

--- a/ftNode/conf/ftNode_yarprobotinterface.xml
+++ b/ftNode/conf/ftNode_yarprobotinterface.xml
@@ -6,7 +6,7 @@
     <device type="serialport" name="SerialportDevice">
         <param name="verbose"> 0 </param>
         <!--<param name="comport"> COM5 </param> -->        <!--  //windows     -->
-        <param name="comport"> /dev/pts/2 </param>   <!--    //linux     -->
+        <param name="comport"> /dev/pts/4 </param>   <!--    //linux     -->
         <param name="baudrate"> 115200 </param>
         <param name="xonlim"> 0 </param>
         <param name="xofflim"> 0 </param>

--- a/ftNode/conf/ftNode_yarprobotinterface.xml
+++ b/ftNode/conf/ftNode_yarprobotinterface.xml
@@ -6,7 +6,7 @@
     <device type="serialport" name="SerialportDevice">
         <param name="verbose"> 0 </param>
         <!--<param name="comport"> COM5 </param> -->        <!--  //windows     -->
-        <param name="comport"> /dev/pts/4 </param>   <!--    //linux     -->
+        <param name="comport"> /dev/pts/2 </param>   <!--    //linux     -->
         <param name="baudrate"> 115200 </param>
         <param name="xonlim"> 0 </param>
         <param name="xofflim"> 0 </param>
@@ -31,13 +31,24 @@
     <!--ftNode Device-->
     <device type="ftnode" name="ftNodeDriver">
         <param name="period">0.01</param>
-        <param name="channels">6</param>
+        <param name="numberOfFTSensors">1</param>
         <action phase="startup" level="5" type="attach">
             <paramlist name="networks">
                 <elem name="ftNodeDriverLabel">SerialportDevice</elem>
             </paramlist>
         </action>
         <action phase="shutdown" level="5" type="detach"/>
+    </device>
+
+    <device type="analogServer" name="ftNodeDriverWrapper">
+        <param name="name">/ftNodeDriverWrapper/wrench:o</param>
+        <param name="period">20</param>
+        <action phase="startup" level="5" type="attach">
+            <paramlist name="networks">
+                <elem name="ftNodeDriverWrapperLabel">ftNodeDriver</elem>
+            </paramlist>
+        </action>
+        <action phase="shutdown" level="5" type="detach" />
     </device>
 
 </robot>

--- a/ftNode/conf/ftNode_yarprobotinterface.xml
+++ b/ftNode/conf/ftNode_yarprobotinterface.xml
@@ -32,6 +32,12 @@
     <device type="ftnode" name="ftNodeDriver">
         <param name="period">0.01</param>
         <param name="numberOfFTSensors">4</param>
+        <group name="WRENCH_SCALING_FACTOR">
+            <param name="LeftFront">(1262 1421 4289 52 62 19)</param>
+            <param name="LeftRear">(1110 1319 4330 53 62 18)</param>
+            <param name="RightFront">(1206 1447 4361 52 62 19)</param>
+            <param name="RightRear">(1276 1395 4338 59 61 19)</param>
+        </group>
         <action phase="startup" level="5" type="attach">
             <paramlist name="networks">
                 <elem name="ftNodeDriverLabel">SerialportDevice</elem>

--- a/ftNode/conf/ftNode_yarprobotinterface.xml
+++ b/ftNode/conf/ftNode_yarprobotinterface.xml
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<robot name="ftNodeDriver" build=0 portprefix="">
+<!--Following the example in https://github.com/robotology/robots-configuration/blob/devel/experimentalSetups/battery/hardware/battery/icubbattery.xml-->
+
+    <!--Serial Device-->
+    <device type="serialport" name="SerialportDevice">
+        <param name="verbose"> 0 </param>
+        <!--<param name="comport"> COM5 </param> -->        <!--  //windows     -->
+        <param name="comport"> /dev/pts/4 </param>   <!--    //linux     -->
+        <param name="baudrate"> 115200 </param>
+        <param name="xonlim"> 0 </param>
+        <param name="xofflim"> 0 </param>
+        <param name="readmincharacters"> 0 </param>
+        <param name="readtimeoutmsec"> 5 </param>
+        <param name="parityenb"> 0 </param>
+        <param name="paritymode"> none </param>
+        <param name="ctsenb"> 0 </param>
+        <param name="rtsenb"> 0 </param>
+        <param name="xinenb"> 0 </param>
+        <param name="xoutenb"> 0 </param>
+        <param name="modem"> 0 </param>
+        <param name="rcvenb"> 0 </param>
+        <param name="dsrenb"> 0 </param>
+        <param name="dtrdisable"> 0 </param>
+        <param name="databits"> 8 </param>
+        <param name="stopbits"> 1 </param>
+        <param name="line_terminator_char1"> 10 </param>
+        <param name="line_terminator_char2">  10 </param>
+    </device>
+
+    <!--ftNode Device-->
+    <device type="ftnode" name="ftNodeDriver">
+        <param name="period">0.01</param>
+        <param name="channels">6</param>
+        <action phase="startup" level="5" type="attach">
+            <paramlist name="networks">
+                <elem name="ftNodeDriverLabel">SerialportDevice</elem>
+            </paramlist>
+        </action>
+        <action phase="shutdown" level="5" type="detach"/>
+    </device>
+
+</robot>

--- a/ftNode/conf/ftNode_yarprobotinterface.xml
+++ b/ftNode/conf/ftNode_yarprobotinterface.xml
@@ -5,13 +5,13 @@
     <!--Serial Device-->
     <device type="serialport" name="SerialportDevice">
         <param name="verbose"> 0 </param>
-        <!--<param name="comport"> COM5 </param> -->        <!--  //windows     -->
-        <param name="comport">  /dev/ttyACM0 </param>   <!--    //linux     -->
+        <param name="comport"> COM2 </param>        <!--  //windows     -->
+        <!--param name="comport">  /dev/ttyACM0 </param-->   <!--    //linux     -->
         <param name="baudrate"> 115200 </param>
         <param name="xonlim"> 0 </param>
         <param name="xofflim"> 0 </param>
         <param name="readmincharacters"> 0 </param>
-        <param name="readtimeoutmsec"> 5 </param>
+        <param name="readtimeoutmsec"> 50 </param>
         <param name="parityenb"> 0 </param>
         <param name="paritymode"> none </param>
         <param name="ctsenb"> 0 </param>
@@ -25,7 +25,7 @@
         <param name="databits"> 8 </param>
         <param name="stopbits"> 1 </param>
         <param name="line_terminator_char1"> 10 </param>
-        <param name="line_terminator_char2">  10 </param>
+        <param name="line_terminator_char2">  13 </param>
     </device>
 
     <!--ftNode Device-->

--- a/ftNode/conf/ftNode_yarprobotinterface.xml
+++ b/ftNode/conf/ftNode_yarprobotinterface.xml
@@ -6,7 +6,7 @@
     <device type="serialport" name="SerialportDevice">
         <param name="verbose"> 0 </param>
         <!--<param name="comport"> COM5 </param> -->        <!--  //windows     -->
-        <param name="comport"> /dev/pts/4 </param>   <!--    //linux     -->
+        <param name="comport">  /dev/ttyACM0 </param>   <!--    //linux     -->
         <param name="baudrate"> 115200 </param>
         <param name="xonlim"> 0 </param>
         <param name="xofflim"> 0 </param>
@@ -31,7 +31,7 @@
     <!--ftNode Device-->
     <device type="ftnode" name="ftNodeDriver">
         <param name="period">0.01</param>
-        <param name="numberOfFTSensors">1</param>
+        <param name="numberOfFTSensors">4</param>
         <action phase="startup" level="5" type="attach">
             <paramlist name="networks">
                 <elem name="ftNodeDriverLabel">SerialportDevice</elem>

--- a/ftNode/conf/ftshoes_YarpScope.xml
+++ b/ftNode/conf/ftshoes_YarpScope.xml
@@ -1,0 +1,107 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<portscope rows="2" columns="2" carrier="mcast">
+ 
+    <!-- The color scheme for the graphs is similar to>
+    <matlab plots color order-->
+
+
+    <!--Left Shoe Force Plots-->
+    <plot gridx="0"
+          gridy="0"
+          title="Left Shoe Force"
+          size="60"
+          minval="-1000"
+          maxval="200"
+          bgcolor="white">
+        <graph remote="/ft/ftShoe_Left/analog:o"
+               index="0"
+               color="#FF0000"
+               title="Fx"
+               type="lines" />
+	<graph remote="/ft/ftShoe_Left/analog:o"
+               index="1"
+               color="#00FF00"
+               title="Fy"
+               type="lines" />
+	<graph remote="/ft/ftShoe_Left/analog:o"
+               index="2"
+               color="#0000FF"
+               title="Fz"
+               type="lines" />
+    </plot>
+	
+	<!--Left Shoe Torque Plots-->
+    <plot gridx="0"
+          gridy="1"
+          title="Left Shoe Torque"
+          size="60"
+          minval="-200"
+          maxval="200"
+          bgcolor="white">
+	<graph remote="/ft/ftShoe_Left/analog:o"
+               index="3"
+               color="#FF0000"
+               title="Tx"
+               type="lines" />
+	<graph remote="/ft/ftShoe_Left/analog:o"
+               index="4"
+               color="#00FF00"
+               title="Ty"
+               type="lines" />
+	<graph remote="/ft/ftShoe_Left/analog:o"
+               index="5"
+               color="#0000FF"
+               title="Tz"
+               type="lines" />
+    </plot>
+
+    <!--Right Shoe Force Plots-->
+    <plot gridx="1"
+          gridy="0"
+          title="Right Shoe Force"
+          size="60"
+          minval="-1000"
+          maxval="200"
+          bgcolor="white">
+        <graph remote="/ft/ftShoe_Right/analog:o"
+               index="0"
+               color="#FF0000"
+               title="Fx"
+               type="lines" />
+	<graph remote="/ft/ftShoe_Right/analog:o"
+               index="1"
+               color="#00FF00"
+               title="Fy"
+               type="lines" />
+	<graph remote="/ft/ftShoe_Right/analog:o"
+               index="2"
+               color="#0000FF"
+               title="Fz"
+               type="lines" />
+    </plot>   
+	
+    <!--Right Shoe Torque Plots-->
+    <plot gridx="1"
+          gridy="1"
+          title="Right Shoe Torque"
+          size="60"
+          minval="-200"
+          maxval="200"
+          bgcolor="white">
+	<graph remote="/ft/ftShoe_Right/analog:o"
+               index="3"
+               color="#FF0000"
+               title="Tx"
+               type="lines" />
+	<graph remote="/ft/ftShoe_Right/analog:o"
+               index="4"
+               color="#00FF00"
+               title="Ty"
+               type="lines" />
+	<graph remote="/ft/ftShoe_Right/analog:o"
+               index="5"
+               color="#0000FF"
+               title="Tz"
+               type="lines" />
+    </plot>   
+</portscope>

--- a/ftNode/conf/serial.ini
+++ b/ftNode/conf/serial.ini
@@ -1,0 +1,29 @@
+/// An initialization file with all possible parameter for configuring the dserial port and adequate defaults.
+
+verbose 1
+comport COM2 //Windows
+//comport /dev/ttyACM0 //Linux
+baudrate 115200
+xonlim 0
+xofflim 0
+readmincharacters 1
+readtimeoutmsec 100
+paritymode none
+ctsenb 0
+rtsenb 0
+xinenb 0
+xoutenb 0
+modem 0
+rcvenb 0
+dsrenb 0
+dtrdisable 0
+databits 8
+stopbits 1
+line_terminator_char1 10
+line_terminator_char2 13
+
+[plugin serialport]
+type device
+name serialport
+library yarp_serialport
+wrapper serial

--- a/ftNode/ftnode.ini
+++ b/ftNode/ftnode.ini
@@ -1,0 +1,5 @@
+[plugin ftnode]
+type device
+name ftnode
+library ftnode
+wrapper analogServer

--- a/ftNode/ftnodeDriver.cpp
+++ b/ftNode/ftnodeDriver.cpp
@@ -7,6 +7,8 @@
 #include "ftnodeDriver.h"
 
 #include <yarp/os/LogStream.h>
+#include <yarp/os/Bottle.h>
+#include <yarp/os/Time.h>
 
 #include <mutex>
 #include <string>
@@ -26,11 +28,26 @@ struct AnalogSensorData
     std::vector<double> measurements;
 };
 
+struct SerialPortWrenchData
+{
+    std::vector<double> forceBuffer;
+    bool forceUpdateFlag;
+
+    std::vector<double> torqueBuffer;
+    bool torqueUpdateFlag;
+
+};
+
 class ftnodeDriver::Impl
 {
 public:
     mutable std::mutex mutex;
     yarp::dev::ISerialDevice *iSerialDevice = nullptr;
+
+    std::string serialComPortName;
+
+    // Buffer for storing data from serial port
+    std::vector<SerialPortWrenchData> serialPortWrenchDataVector;
 
     int numberOfFTSensors;
     AnalogSensorData analogSensorData;
@@ -48,7 +65,9 @@ ftnodeDriver::~ftnodeDriver() = default;
 
 bool ftnodeDriver::open(yarp::os::Searchable& config)
 {
+    // ==================================
     // Check the configuration parameters
+    // ==================================
 
     // Period of the this device
     if (!(config.check("period") && config.find("period").isFloat64())) {
@@ -67,13 +86,25 @@ bool ftnodeDriver::open(yarp::os::Searchable& config)
         return false;
     }
 
+    // ==================================
     // Parse the configuration parameters
+    // ==================================
 
     pImpl->numberOfFTSensors = config.find("numberOfFTSensors").asInt();
 
+    // Initialize the serial port data buffers vector
+    pImpl->serialPortWrenchDataVector.resize(pImpl->numberOfFTSensors);
+
+    for (size_t i = 0; i < pImpl->numberOfFTSensors; i++) {
+        pImpl->serialPortWrenchDataVector.at(i).forceBuffer.resize(3, 0.0);
+        pImpl->serialPortWrenchDataVector.at(i).torqueBuffer.resize(3, 0.0);
+
+        pImpl->serialPortWrenchDataVector.at(i).forceUpdateFlag = false;
+        pImpl->serialPortWrenchDataVector.at(i).torqueUpdateFlag = false;
+    }
+
     // Set the number of channels, 6 for each FT sensor
     pImpl->analogSensorData.numberOfChannels = pImpl->numberOfFTSensors * 6;
-
 
     // Resize the measurements buffer and initialize to zero
     pImpl->analogSensorData.measurements.resize(pImpl->analogSensorData.numberOfChannels, 0.0);
@@ -85,21 +116,111 @@ bool ftnodeDriver::open(yarp::os::Searchable& config)
 void ftnodeDriver::run()
 {
     //TODO - Process data from the serial port
-    yInfo() << LogPrefix << "Inside run";
+    //yInfo() << LogPrefix << "Inside run";
+
+    // Read the incoming serial port messages in a bottle
+    yarp::os::Bottle serialPortMsg;
+    // TODO: Double check if the call to receive a bottle is correct for reading serial port data
+    bool newMsg = pImpl->iSerialDevice->receive(serialPortMsg);
+
+    if (serialPortMsg.size() != 0) {
+
+        //yInfo() << LogPrefix << "received message size : " << serialPortMsg.size();
+        //yInfo() << LogPrefix << "received message : " << serialPortMsg.get(0).asDouble();
+
+        // Get the received serial message as a string
+        std::string msgString = serialPortMsg.get(0).asString();
+        yarp::os::Bottle extractedMsgBottle;
+
+        // Extract each word
+        std::string msg;
+        std::stringstream iss(msgString);
+
+        while (iss >> msg) {
+
+            // TODO: Check the precision during conversion from string to double
+            double value = atof(msg.c_str());
+            extractedMsgBottle.addFloat64(value);
+            //yInfo() << LogPrefix << "Extracted word : " << msg << " " << value;
+
+        }
+
+        // Check the size of the extracted message
+        // The incoming serial message expected structure is
+        // (fx/tx) (fy/ty) (fz/tz) (canAddress) (force/torque)
+        if (extractedMsgBottle.size() != 5) {
+            yWarning() << LogPrefix << "Extracted serial message structure is incorrect."
+                                       " Expected data structure is (fx/tx) (fy/ty) (fz/tz) (canAddress) (force/torque)";
+        }
+
+        //yInfo() << LogPrefix << "Extracted message bottle size : " << extractedMsgBottle.size();
+        yInfo() << LogPrefix << "Extracted message bottle data : " << extractedMsgBottle.toString().c_str();
+
+        // Get force/torque components
+        double xcomponent = extractedMsgBottle.get(0).asDouble();
+        double ycomponent = extractedMsgBottle.get(1).asDouble();
+        double zcomponent = extractedMsgBottle.get(2).asDouble();
+
+        // Get CAN address or wrench source number
+        // FTShoes has CAN address as [1 2 3 4]
+        // In case this changes, we need to consider a mapping through the parameter configuration
+        int wrenchSourceNumber = extractedMsgBottle.get(3).asInt();
+
+        if (wrenchSourceNumber > pImpl->numberOfFTSensors) {
+            yWarning() << LogPrefix << "CANAddress or wrench source number from the serial message is more than"
+                                     " the wrench source number specified in the configuration file";
+        }
+
+        // Check if the message is force or torque components
+        int messageType = extractedMsgBottle.get(4).asInt();
+
+        // Populate the serial message buffer
+        if (messageType == 1) { //force
+
+            pImpl->serialPortWrenchDataVector.at(wrenchSourceNumber).forceBuffer.at(0) = xcomponent;
+            pImpl->serialPortWrenchDataVector.at(wrenchSourceNumber).forceBuffer.at(1) = ycomponent;
+            pImpl->serialPortWrenchDataVector.at(wrenchSourceNumber).forceBuffer.at(2) = zcomponent;
+
+            pImpl->serialPortWrenchDataVector.at(wrenchSourceNumber).forceUpdateFlag = true;
+        }
+        else if (messageType == 2) { //torque
+
+            pImpl->serialPortWrenchDataVector.at(wrenchSourceNumber).torqueBuffer.at(0) = xcomponent;
+            pImpl->serialPortWrenchDataVector.at(wrenchSourceNumber).torqueBuffer.at(1) = ycomponent;
+            pImpl->serialPortWrenchDataVector.at(wrenchSourceNumber).torqueBuffer.at(2) = zcomponent;
+
+            pImpl->serialPortWrenchDataVector.at(wrenchSourceNumber).torqueUpdateFlag = true;
+        }
+
+    }
+    else {
+        //yInfo() << LogPrefix << "Waiting for message on the serial port " << pImpl->serialComPortName;
+    }
+
 
     for(size_t i = 0; i < pImpl->numberOfFTSensors; i++) {
 
-        // Expose the data as IAnalogSensor
-        // ================================
-        {
-            std::lock_guard<std::mutex> lock(pImpl->mutex);
+        std::lock_guard<std::mutex> lock(pImpl->mutex);
 
-            pImpl->analogSensorData.measurements[6 * i + 0] = 0.0;
-            pImpl->analogSensorData.measurements[6 * i + 1] = 0.0;
-            pImpl->analogSensorData.measurements[6 * i + 2] = 0.0;
-            pImpl->analogSensorData.measurements[6 * i + 3] = 0.0;
-            pImpl->analogSensorData.measurements[6 * i + 4] = 0.0;
-            pImpl->analogSensorData.measurements[6 * i + 5] = 0.0;
+        // Expose the data to IAnalogSensor when the complete message for a wrench source is updated
+        if (pImpl->serialPortWrenchDataVector.at(i).forceUpdateFlag && pImpl->serialPortWrenchDataVector.at(i).torqueUpdateFlag) {
+
+            // Expose the data as IAnalogSensor
+            // ================================
+            {
+                pImpl->analogSensorData.measurements[6 * i + 0] = pImpl->serialPortWrenchDataVector.at(i).forceBuffer.at(0);
+                pImpl->analogSensorData.measurements[6 * i + 1] = pImpl->serialPortWrenchDataVector.at(i).forceBuffer.at(1);
+                pImpl->analogSensorData.measurements[6 * i + 2] = pImpl->serialPortWrenchDataVector.at(i).forceBuffer.at(2);
+                pImpl->analogSensorData.measurements[6 * i + 3] = pImpl->serialPortWrenchDataVector.at(i).torqueBuffer.at(0);
+                pImpl->analogSensorData.measurements[6 * i + 4] = pImpl->serialPortWrenchDataVector.at(i).torqueBuffer.at(1);
+                pImpl->analogSensorData.measurements[6 * i + 5] = pImpl->serialPortWrenchDataVector.at(i).torqueBuffer.at(2);
+
+                // Clear the serial message buffer after updating the IAnalogSensor buffers
+                pImpl->serialPortWrenchDataVector.at(i).forceBuffer.clear();
+                pImpl->serialPortWrenchDataVector.at(i).torqueBuffer.clear();
+                pImpl->serialPortWrenchDataVector.at(i).forceUpdateFlag = false;
+                pImpl->serialPortWrenchDataVector.at(i).torqueUpdateFlag = false;
+            }
         }
 
     }
@@ -126,6 +247,9 @@ bool ftnodeDriver::attach(yarp::dev::PolyDriver* poly)
         yInfo() << LogPrefix << "ISerialDevice interface viewed correctly";
     }
 
+    // Get the comport name of the serial device
+    pImpl->serialComPortName = poly->getValue("comport").asString();
+
     // TODO: Check if the ISerialDevice interface is configured correctly
     // I do not see any method to check this
 
@@ -142,6 +266,10 @@ bool ftnodeDriver::attach(yarp::dev::PolyDriver* poly)
 
 bool ftnodeDriver::detach()
 {
+    while(yarp::os::PeriodicThread::isRunning()) {
+        yarp::os::PeriodicThread::stop();
+    }
+
     pImpl->iSerialDevice = nullptr;
     return true;
 }

--- a/ftNode/ftnodeDriver.cpp
+++ b/ftNode/ftnodeDriver.cpp
@@ -1,0 +1,86 @@
+/*
+ * Copyright (C) 2019 iCub Facility
+ * Authors: Yeshasvi Tirupachuri
+ * CopyPolicy: Released under the terms of the LGPLv2.1 or later, see LGPL.TXT
+ */
+
+#include "ftnodeDriver.h"
+
+#include <yarp/os/LogStream.h>
+
+#include <mutex>
+#include <string>
+#include <stdio.h>
+
+const std::string DeviceName = "ftnodeDriver";
+const std::string LogPrefix = DeviceName + ":";
+
+using namespace yarp::dev;
+using namespace yarp::os;
+
+class ftnodeDriver::Impl
+{
+public:
+    mutable std::recursive_mutex mutex;
+    yarp::dev::ISerialDevice *iSerialDevice = nullptr;
+};
+
+
+// Default constructor
+ftnodeDriver::ftnodeDriver()
+    : pImpl{new Impl()}
+{}
+
+// Destructor
+ftnodeDriver::~ftnodeDriver() = default;
+
+bool ftnodeDriver::open(yarp::os::Searchable& config)
+{
+    // TODO
+}
+
+bool ftnodeDriver::close()
+{
+    detach();
+    return true;
+}
+
+bool ftnodeDriver::attach(yarp::dev::PolyDriver* poly)
+{
+    if (!poly) {
+        yError() << LogPrefix << "Passed PolyDriver is a nullptr";
+        return false;
+    }
+
+    // TODO: Check for ISerialDevice interface
+}
+
+bool ftnodeDriver::detach()
+{
+    // TODO Set interfaces to nullptr
+    return true;
+}
+
+bool ftnodeDriver::attachAll(const yarp::dev::PolyDriverList& driverList)
+{
+    // TODO: Check how many serial devices are needed for the ft wireless sheos
+    if (driverList.size() > 1) {
+        yError() << LogPrefix << "This wrapper accepts only one attached yarp Serial device";
+        return false;
+    }
+
+    const yarp::dev::PolyDriverDescriptor* driver = driverList[0];
+
+    if (!driver) {
+        yError() << LogPrefix << "Passed PolyDriverDescriptor is nullptr";
+        return false;
+    }
+
+    return attach(driver->poly);
+}
+
+bool ftnodeDriver::detachAll()
+{
+    // TODO: Update in case of multiple serial devices are attached
+    return detach();
+}

--- a/ftNode/ftnodeDriver.cpp
+++ b/ftNode/ftnodeDriver.cpp
@@ -213,14 +213,14 @@ void ftnodeDriver::run()
             for (size_t subMsgIndex = 0; subMsgIndex < 4; subMsgIndex++) {
 
                 // Get force/torque components
-                double xcomponentMSB = extractedMsgBottle.get(8 * subMsgIndex + 0).asFloat64();
-                double xcomponentLSB = extractedMsgBottle.get(8 * subMsgIndex + 1).asFloat64();
+                double xcomponentMSB = extractedMsgBottle.get(8 * subMsgIndex + 1).asFloat64();
+                double xcomponentLSB = extractedMsgBottle.get(8 * subMsgIndex + 0).asFloat64();
 
-                double ycomponentMSB = extractedMsgBottle.get(8 * subMsgIndex + 2).asFloat64();
-                double ycomponentLSB = extractedMsgBottle.get(8 * subMsgIndex + 3).asFloat64();
+                double ycomponentMSB = extractedMsgBottle.get(8 * subMsgIndex + 3).asFloat64();
+                double ycomponentLSB = extractedMsgBottle.get(8 * subMsgIndex + 2).asFloat64();
 
-                double zcomponentMSB = extractedMsgBottle.get(8 * subMsgIndex + 4).asFloat64();
-                double zcomponentLSB = extractedMsgBottle.get(8 * subMsgIndex + 5).asFloat64();
+                double zcomponentMSB = extractedMsgBottle.get(8 * subMsgIndex + 5).asFloat64();
+                double zcomponentLSB = extractedMsgBottle.get(8 * subMsgIndex + 4).asFloat64();
 
                 // Compute correct values based on MSB LSB
                 double xcomponent = xcomponentMSB * 256 + xcomponentLSB;

--- a/ftNode/ftnodeDriver.cpp
+++ b/ftNode/ftnodeDriver.cpp
@@ -176,15 +176,11 @@ void ftnodeDriver::run()
     char charMsg[5000];
     int size = pImpl->iSerialDevice->receiveLine(charMsg, 5000);
 
-    yInfo() << LogPrefix << "Received char serial message size is " << size;
-
     std::string serialPortMsg(charMsg);
-    yInfo() << LogPrefix << "Received char serial message is " << serialPortMsg;
-    
+
     if (serialPortMsg.size() != 0) {
 
         // Get the received serial message as a string
-        //std::string msgString = serialPortMsg.get(0).asString();
         yarp::os::Bottle extractedMsgBottle;
 
         // Extract each word
@@ -198,12 +194,9 @@ void ftnodeDriver::run()
             // TODO: Check the precision during conversion from string to double
             double value = atof(msg.c_str());
             extractedMsgBottle.addFloat64(value);
-            yInfo() << LogPrefix << "Extracted word : " << msg << " " << value;
 
         }
 
-        yInfo() << LogPrefix << "Extracted message bottle size : " << extractedMsgBottle.size();
-        yInfo() << LogPrefix << "Extracted message bottle data : " << extractedMsgBottle.toString().c_str();
 
         // Check the size of the extracted message
         // The incoming serial message expected structure is for two FTSensors
@@ -216,18 +209,8 @@ void ftnodeDriver::run()
         }
         else
         {
-            // Process first sub message
+            // Process sub messages from the received line
             for (size_t subMsgIndex = 0; subMsgIndex < 4; subMsgIndex++) {
-
-                yInfo() << LogPrefix << "Sub msg index : " << subMsgIndex;
-                yInfo() << LogPrefix << extractedMsgBottle.get(8 * subMsgIndex + 0).asFloat64() << " "
-                        << extractedMsgBottle.get(8 * subMsgIndex + 1).asFloat64() << " "
-                        << extractedMsgBottle.get(8 * subMsgIndex + 2).asFloat64() << " "
-                        << extractedMsgBottle.get(8 * subMsgIndex + 3).asFloat64() << " "
-                        << extractedMsgBottle.get(8 * subMsgIndex + 4).asFloat64() << " "
-                        << extractedMsgBottle.get(8 * subMsgIndex + 5).asFloat64() << " "
-                        << extractedMsgBottle.get(8 * subMsgIndex + 6).asFloat64() << " "
-                        << extractedMsgBottle.get(8 * subMsgIndex + 7).asFloat64() << " ";
 
                 // Get force/torque components
                 double xcomponentMSB = extractedMsgBottle.get(8 * subMsgIndex + 0).asFloat64();
@@ -248,8 +231,6 @@ void ftnodeDriver::run()
                 // FTShoes has CAN address as [1 2 3 4]
                 // In case this changes, we need to consider a mapping through the parameter configuration
                 int wrenchSourceNumber = extractedMsgBottle.get(8 * subMsgIndex + 6).asFloat64();
-
-                yInfo() << LogPrefix << "Wrench source : " << wrenchSourceNumber;
 
                 if (wrenchSourceNumber > pImpl->numberOfFTSensors) {
                     yWarning() << LogPrefix << "CANAddress or wrench source number from the serial message is more than"
@@ -283,10 +264,6 @@ void ftnodeDriver::run()
         }
 
     }
-    else {
-        //yInfo() << LogPrefix << "Waiting for message on the serial port " << pImpl->serialComPortName;
-    }
-
 
     for(size_t i = 0; i < pImpl->numberOfFTSensors; i++) {
 

--- a/ftNode/ftnodeDriver.cpp
+++ b/ftNode/ftnodeDriver.cpp
@@ -11,24 +11,35 @@
 #include <mutex>
 #include <string>
 #include <stdio.h>
+#include <vector>
 
 const std::string DeviceName = "ftnodeDriver";
 const std::string LogPrefix = DeviceName + ":";
+double period = 0.01;
 
 using namespace yarp::dev;
 using namespace yarp::os;
+
+struct AnalogSensorData
+{
+    size_t numberOfChannels = 0;
+    std::vector<double> measurements;
+};
 
 class ftnodeDriver::Impl
 {
 public:
     mutable std::recursive_mutex mutex;
     yarp::dev::ISerialDevice *iSerialDevice = nullptr;
+
+    AnalogSensorData analogSensorData;
 };
 
 
 // Default constructor
 ftnodeDriver::ftnodeDriver()
-    : pImpl{new Impl()}
+    : PeriodicThread(period)
+    , pImpl{new Impl()}
 {}
 
 // Destructor
@@ -36,7 +47,40 @@ ftnodeDriver::~ftnodeDriver() = default;
 
 bool ftnodeDriver::open(yarp::os::Searchable& config)
 {
-    // TODO
+    // Check the configuration parameters
+
+    // Period of the this device
+    if (!(config.check("period") && config.find("period").isFloat64())) {
+        yInfo() << LogPrefix << "Using default period: " << period << "s";
+    }
+    else {
+        period = config.find("period").asFloat64();
+        yInfo() << LogPrefix << "Using the period : " << period << "s";
+    }
+
+    // The number of channels to be configured for IAnalogSensor interface
+    // Currently, the serial port streams data from only one FT and in the
+    // future it will also stream the data from the four FTs of the FTshoes
+    if (!(config.check("channels") && config.find("channels").isInt())) {
+        yError() << LogPrefix << "Option 'channels' not found or not a valid integer";
+        return false;
+    }
+
+    // Parse the configuration parameters
+
+    pImpl->analogSensorData.numberOfChannels = config.find("channels").asInt();
+
+    // Resize the measurements buffer and initialize to zero
+    pImpl->analogSensorData.measurements.resize(pImpl->analogSensorData.numberOfChannels * 6, 0.0);
+
+    return true;
+
+}
+
+void ftnodeDriver::run()
+{
+    //TODO
+    yInfo() << LogPrefix << "Inside run";
 }
 
 bool ftnodeDriver::close()
@@ -53,11 +97,31 @@ bool ftnodeDriver::attach(yarp::dev::PolyDriver* poly)
     }
 
     // TODO: Check for ISerialDevice interface
+    if (pImpl->iSerialDevice || !poly->view(pImpl->iSerialDevice) || !pImpl->iSerialDevice) {
+        yError() << LogPrefix << "Failed to view the ISerialDevice interface from the attached polydriver device";
+        return false;
+    }
+    else {
+        yInfo() << LogPrefix << "ISerialDevice interface viewed correctly";
+    }
+
+    // TODO: Check if the ISerialDevice interface is configured correctly
+    // I do not see any method to check this
+
+    // Start the PeriodicThread loop
+    if (!start()) {
+        yError() << LogPrefix << "Failed to start the period thread.";
+        return false;
+    }
+
+    yInfo() << LogPrefix << "attach() successful";
+    return true;
+
 }
 
 bool ftnodeDriver::detach()
 {
-    // TODO Set interfaces to nullptr
+    pImpl->iSerialDevice = nullptr;
     return true;
 }
 
@@ -84,3 +148,6 @@ bool ftnodeDriver::detachAll()
     // TODO: Update in case of multiple serial devices are attached
     return detach();
 }
+
+void ftnodeDriver::threadRelease()
+{}

--- a/ftNode/ftnodeDriver.h
+++ b/ftNode/ftnodeDriver.h
@@ -45,6 +45,7 @@ public:
       bool close() override;
 
       // IPreciselyTimed
+      // TODO: Check if we need this interface
       //yarp::os::Stamp getLastInputStamp() override;
 
       // PeriodicThread

--- a/ftNode/ftnodeDriver.h
+++ b/ftNode/ftnodeDriver.h
@@ -1,0 +1,61 @@
+/*
+ * Copyright (C) 2019 iCub Facility
+ * Authors: Yeshasvi Tirupachuri
+ * CopyPolicy: Released under the terms of the LGPLv2.1 or later, see LGPL.TXT
+ */
+
+#ifndef YARP_ftnodeDriver_H
+#define YARP_ftnodeDriver_H
+
+#include <yarp/dev/DeviceDriver.h>
+#include <yarp/dev/PolyDriver.h>
+#include <yarp/dev/Wrapper.h>
+#include <yarp/dev/SerialInterfaces.h>
+#include <yarp/dev/IAnalogSensor.h>
+#include <yarp/dev/PreciselyTimed.h>
+
+
+namespace yarp {
+    namespace dev {
+        class ftnodeDriver;
+    } // namespace dev
+} // namespace yarp
+
+class yarp::dev::ftnodeDriver :
+        //public yarp::dev::ISerialDevice,
+        //public yarp::dev::IAnalogSensor,
+        public yarp::dev::DeviceDriver,
+        public yarp::dev::IPreciselyTimed,
+        public yarp::dev::IWrapper,
+        public yarp::dev::IMultipleWrapper
+{
+
+private:
+    class Impl;
+    std::unique_ptr<Impl> pImpl;
+
+public:
+      ftnodeDriver();
+      ~ftnodeDriver() override;
+
+      // DeviceDriver
+      bool open(yarp::os::Searchable& config) override;
+      bool close() override;
+
+      // IPreciselyTimed
+      yarp::os::Stamp getLastInputStamp() override;
+
+      // IWrapper interface
+      bool attach(yarp::dev::PolyDriver* poly) override;
+      bool detach() override;
+
+      // IMultipleWrapper interface
+      bool attachAll(const yarp::dev::PolyDriverList& driverList) override;
+      bool detachAll() override;
+
+      // IAnalogSensor interfaces
+      // TODO
+
+};
+
+#endif // YARP_ftnodeDriver_H

--- a/ftNode/ftnodeDriver.h
+++ b/ftNode/ftnodeDriver.h
@@ -13,6 +13,7 @@
 #include <yarp/dev/SerialInterfaces.h>
 #include <yarp/dev/IAnalogSensor.h>
 #include <yarp/dev/PreciselyTimed.h>
+#include <yarp/os/PeriodicThread.h>
 
 
 namespace yarp {
@@ -25,7 +26,8 @@ class yarp::dev::ftnodeDriver :
         //public yarp::dev::ISerialDevice,
         //public yarp::dev::IAnalogSensor,
         public yarp::dev::DeviceDriver,
-        public yarp::dev::IPreciselyTimed,
+        //public yarp::dev::IPreciselyTimed,
+        public yarp::os::PeriodicThread,
         public yarp::dev::IWrapper,
         public yarp::dev::IMultipleWrapper
 {
@@ -43,7 +45,11 @@ public:
       bool close() override;
 
       // IPreciselyTimed
-      yarp::os::Stamp getLastInputStamp() override;
+      //yarp::os::Stamp getLastInputStamp() override;
+
+      // PeriodicThread
+      void run() override;
+      void threadRelease() override;
 
       // IWrapper interface
       bool attach(yarp::dev::PolyDriver* poly) override;

--- a/ftNode/ftnodeDriver.h
+++ b/ftNode/ftnodeDriver.h
@@ -24,7 +24,7 @@ namespace yarp {
 
 class yarp::dev::ftnodeDriver :
         //public yarp::dev::ISerialDevice,
-        //public yarp::dev::IAnalogSensor,
+        public yarp::dev::IAnalogSensor,
         public yarp::dev::DeviceDriver,
         //public yarp::dev::IPreciselyTimed,
         public yarp::os::PeriodicThread,
@@ -59,9 +59,14 @@ public:
       bool attachAll(const yarp::dev::PolyDriverList& driverList) override;
       bool detachAll() override;
 
-      // IAnalogSensor interfaces
-      // TODO
-
+      // IAnalogSensor interface
+      int read(yarp::sig::Vector& out) override;
+      int getState(int ch) override;
+      int getChannels() override;
+      int calibrateSensor() override;
+      int calibrateSensor(const yarp::sig::Vector& value) override;
+      int calibrateChannel(int ch) override;
+      int calibrateChannel(int ch, double value) override;
 };
 
 #endif // YARP_ftnodeDriver_H

--- a/ftShoe/ftshoeDriver.cpp
+++ b/ftShoe/ftshoeDriver.cpp
@@ -82,14 +82,14 @@ bool yarp::dev::ftshoeDriver::open(yarp::os::Searchable &config)
     if (useFTNodeDriver) {
 
         // Check for first and second sensor ranges parameter in the configuration
-        if(!config.check("ftNodeFirstSensorRange") || !config.check("ftNodeSecondSenorRange")) {
+        if(!config.check("ftNodeFirstSensorRange") || !config.check("ftNodeSecondSensorRange")) {
             yError() << "ftshoeDriver : ftShoeDriver is configured to use ftNode for incoming data."
                         " Cannot find ftNodeFirstSensorRange or ftNodeSecondSensorRange parameters in the configuration file";
             return false;
         }
 
         if (config.find("ftNodeFirstSensorRange").asList()->size() != 2 ||
-                config.find("ftNodeSecondSenorRange").asList()->size() != 2) {
+                config.find("ftNodeSecondSensorRange").asList()->size() != 2) {
             yError() << "ftshoeDriver : ftNodeFirstSensorRange or ftNodeSecondSensorRange should be list of size 2,"
                         " indicating the range to consider from the data given by ftNode";
             return false;
@@ -106,7 +106,7 @@ bool yarp::dev::ftshoeDriver::open(yarp::os::Searchable &config)
         }
 
         // Get the second sensor range
-        yarp::os::Bottle *secondSensorRange = config.find("ftNodeSecondSenorRange").asList();
+        yarp::os::Bottle *secondSensorRange = config.find("ftNodeSecondSensorRange").asList();
         ftNode_secondSensorRange[0] = secondSensorRange->get(0).asInt();
         ftNode_secondSensorRange[1] = secondSensorRange->get(1).asInt();
 
@@ -482,7 +482,7 @@ bool yarp::dev::ftshoeDriver::attachAll(const yarp::dev::PolyDriverList &driverL
 
         // Check if the channels match atleast the given sensor ranges
         int channels = ftNode_sensor_p->getChannels();
-        if (!(channels >= ftNode_firstSensorRange[1] && channels >= ftNode_secondSensorRange[2])) {
+        if (!(channels >= ftNode_firstSensorRange[1] && channels >= ftNode_secondSensorRange[1])) {
             yError() << "ftShoeDriver : The number of channels from the attached ftNodeDriver are less than the"
                         " upper value of the channel ranges in ftNodeFirstSensorRange or ftNodeSecondSensorRange";
             return false;

--- a/ftShoe/ftshoeDriver.cpp
+++ b/ftShoe/ftshoeDriver.cpp
@@ -30,6 +30,7 @@ yarp::dev::ftshoeDriver::ftshoeDriver() : f_sensorReadings(6),
                                           p_status(yarp::dev::IAnalogSensor::AS_OK),
                                           f_sensor_p(0),
                                           s_sensor_p(0),
+                                          ftNode_sensor_p(0),
                                           fts_offset(3),
                                           fts_orientation_R(3,3),
                                           s_fts_to_out_R(3,3),
@@ -64,6 +65,8 @@ yarp::dev::ftshoeDriver::ftshoeDriver() : f_sensorReadings(6),
     // output timestamp is the mean of timestamps of each sensor
     double mean = (f_timestamp.getTime() + s_timestamp.getTime()) / 2.0;
     devout_timestamp.update(mean);
+
+    ftNode_timestamp.update();
 }
 
 yarp::dev::ftshoeDriver::~ftshoeDriver()
@@ -73,6 +76,46 @@ yarp::dev::ftshoeDriver::~ftshoeDriver()
 
 bool yarp::dev::ftshoeDriver::open(yarp::os::Searchable &config)
 {
+    // Check for optional parameters
+    useFTNodeDriver = config.check("useFTNodeDriver",yarp::os::Value(false)).asBool();
+
+    if (useFTNodeDriver) {
+
+        // Check for first and second sensor ranges parameter in the configuration
+        if(!config.check("ftNodeFirstSensorRange") || !config.check("ftNodeSecondSenorRange")) {
+            yError() << "ftshoeDriver : ftShoeDriver is configured to use ftNode for incoming data."
+                        " Cannot find ftNodeFirstSensorRange or ftNodeSecondSensorRange parameters in the configuration file";
+            return false;
+        }
+
+        if (config.find("ftNodeFirstSensorRange").asList()->size() != 2 ||
+                config.find("ftNodeSecondSenorRange").asList()->size() != 2) {
+            yError() << "ftshoeDriver : ftNodeFirstSensorRange or ftNodeSecondSensorRange should be list of size 2,"
+                        " indicating the range to consider from the data given by ftNode";
+            return false;
+        }
+
+        // Get the first sensor range
+        yarp::os::Bottle *firstSensorRange = config.find("ftNodeFirstSensorRange").asList();
+        ftNode_firstSensorRange[0] = firstSensorRange->get(0).asInt();
+        ftNode_firstSensorRange[1] = firstSensorRange->get(1).asInt();
+
+        if (ftNode_firstSensorRange[0] > ftNode_firstSensorRange[1]) {
+            yError() << "ftshoeDriver : ftNodeFirstSensorRange first value should be less than the second number";
+            return false;
+        }
+
+        // Get the second sensor range
+        yarp::os::Bottle *secondSensorRange = config.find("ftNodeSecondSenorRange").asList();
+        ftNode_secondSensorRange[0] = secondSensorRange->get(0).asInt();
+        ftNode_secondSensorRange[1] = secondSensorRange->get(1).asInt();
+
+        if (ftNode_secondSensorRange[0] > ftNode_secondSensorRange[1]) {
+            yError() << "ftshoeDriver : ftNodeSecondSenorRange first value should be less than the second number";
+            return false;
+        }
+    }
+
     yarp::os::LockGuard guard(p_mutex);
 
     prop.fromString(config.toString().c_str());
@@ -202,10 +245,29 @@ int yarp::dev::ftshoeDriver::read(yarp::sig::Vector &out)
 {
     out.resize(6);
     yarp::os::LockGuard guard(p_mutex);
-    f_status = f_sensor_p->read(f_sensorReadings);
-    f_timestamp.update();
-    s_status = s_sensor_p->read(s_sensorReadings);
-    s_timestamp.update();
+
+    if (useFTNodeDriver) {
+
+        ftNode_status = ftNode_sensor_p->read(ftNode_sensorReadings);
+        ftNode_timestamp.update();
+
+        // Extract first sensor data and set the time stamp
+        f_sensorReadings = ftNode_sensorReadings.subVector(ftNode_firstSensorRange[0], ftNode_firstSensorRange[1]);
+        f_timestamp = ftNode_timestamp;
+
+        // Extract second sensor data and set the time stamp
+        s_sensorReadings = ftNode_sensorReadings.subVector(ftNode_secondSensorRange[0], ftNode_secondSensorRange[1]);
+        s_timestamp = ftNode_timestamp;
+
+    }
+    else {
+
+        f_status = f_sensor_p->read(f_sensorReadings);
+        f_timestamp.update();
+        s_status = s_sensor_p->read(s_sensorReadings);
+        s_timestamp.update();
+
+    }
 
     // Change sign to obtain the wrenches exerted by the human on the fts,
     // while the fts measure the vice versa
@@ -395,39 +457,76 @@ bool yarp::dev::ftshoeDriver::detach()
 
 bool yarp::dev::ftshoeDriver::attachAll(const yarp::dev::PolyDriverList &driverList)
 {
+    if (useFTNodeDriver) {
 
-    if (driverList.size() != 2)
-    {
-        yError("ftShoeDriver: cannot attach more or less than two devices");
-        return false;
+        if (driverList.size() != 1) {
+            yError() << "ftShoeDriver: Configuration set to use ftNodeDriver and expects to attach to only one ftNodeDevice";
+            return false;
+        }
+
+        const yarp::dev::PolyDriverDescriptor *ftNodeDriver = driverList[0];
+        if (!ftNodeDriver) {
+            yError() << "ftShoeDriver: Failed to get the driver";
+            return false;
+        }
+
+        yarp::os::LockGuard guard(p_mutex);
+
+        if (ftNode_sensor_p ||
+            !ftNodeDriver->poly->view(ftNode_sensor_p) || !ftNode_sensor_p) {
+            yError() << "ftShoeDriver : Failed to view the IAnalogServer interface from the attached ftNodeDriver device";
+            return false;
+        }
+
+        ftNode_status = ftNode_sensor_p->getChannels() > 0 ? AS_OK : AS_ERROR;
+
+        // Check if the channels match atleast the given sensor ranges
+        int channels = ftNode_sensor_p->getChannels();
+        if (!(channels >= ftNode_firstSensorRange[1] && channels >= ftNode_secondSensorRange[2])) {
+            yError() << "ftShoeDriver : The number of channels from the attached ftNodeDriver are less than the"
+                        " upper value of the channel ranges in ftNodeFirstSensorRange or ftNodeSecondSensorRange";
+            return false;
+        }
+
+        return true;
+
     }
+    else {
 
-    const yarp::dev::PolyDriverDescriptor *firstDriver = driverList[0];
-    if (!firstDriver) {
-        yError("Failed to get the driver descriptor");
-        return false;
+        if (driverList.size() != 2)
+        {
+            yError("ftShoeDriver: cannot attach more or less than two devices");
+            return false;
+        }
+
+        const yarp::dev::PolyDriverDescriptor *firstDriver = driverList[0];
+        if (!firstDriver) {
+            yError("Failed to get the driver descriptor");
+            return false;
+        }
+
+        const yarp::dev::PolyDriverDescriptor *secondDriver = driverList[1];
+        if (!secondDriver) {
+            yError("Failed to get the driver descriptor");
+            return false;
+        }
+
+        yarp::os::LockGuard guard(p_mutex);
+
+        // attach the first ftSensor
+        if (!firstDriver->poly || f_sensor_p) return false;
+        if (!firstDriver->poly->view(f_sensor_p) || !f_sensor_p) return false;
+        f_status = f_sensor_p->getChannels() > 0 ? AS_OK : AS_ERROR;
+
+        // attach the second ftSensor
+        if (!secondDriver->poly || s_sensor_p) return false;
+        if (!secondDriver->poly->view(s_sensor_p) || !s_sensor_p) return false;
+        s_status = s_sensor_p->getChannels() > 0 ? AS_OK : AS_ERROR;
+
+        // return 1 if everything went fine with attachAll
+        return !(f_status && s_status);
+
     }
-
-    const yarp::dev::PolyDriverDescriptor *secondDriver = driverList[1];
-    if (!secondDriver) {
-        yError("Failed to get the driver descriptor");
-        return false;
-    }
-
-    yarp::os::LockGuard guard(p_mutex);
-
-    // attach the first ftSensor
-    if (!firstDriver->poly || f_sensor_p) return false;
-    if (!firstDriver->poly->view(f_sensor_p) || !f_sensor_p) return false;
-    f_status = f_sensor_p->getChannels() > 0 ? AS_OK : AS_ERROR;
-
-    // attach the second ftSensor
-    if (!secondDriver->poly || s_sensor_p) return false;
-    if (!secondDriver->poly->view(s_sensor_p) || !s_sensor_p) return false;
-    s_status = s_sensor_p->getChannels() > 0 ? AS_OK : AS_ERROR;
-
-    // return 1 if everything went fine with attachAll
-    return !(f_status && s_status);
 }
 
 bool yarp::dev::ftshoeDriver::detachAll()

--- a/ftShoe/ftshoeDriver.h
+++ b/ftShoe/ftshoeDriver.h
@@ -48,6 +48,12 @@ private:
     yarp::os::Stamp f_timestamp;
     yarp::os::Stamp s_timestamp;
 
+    // Buffers for ftNode data
+    bool useFTNodeDriver;
+    yarp::sig::Vector ftNode_sensorReadings;
+    int ftNode_firstSensorRange[2];
+    int ftNode_secondSensorRange[2];
+
     // Buffers of output data and timestamp
     yarp::sig::Vector devout_data;
     yarp::os::Stamp devout_timestamp;
@@ -63,6 +69,10 @@ private:
 
     yarp::dev::IAnalogSensor *f_sensor_p;
     yarp::dev::IAnalogSensor *s_sensor_p;
+
+    yarp::dev::IAnalogSensor *ftNode_sensor_p;
+    yarp::os::Stamp ftNode_timestamp;
+    int ftNode_status;
 
     // ftShoe settings
     // offset between the two ftSensors expressed in second (rear) ftSensor SoR


### PR DESCRIPTION
This PR adds a new ftNode device driver, that connects to a yarp serial port device containing data from the wireless receiver of the FTShoes. Additionally, it also modified the ftShoe driver to  attach to the ftNode driver and read the FT data.