### PR TITLE
Clean up AMTI drivers Compilation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,6 +3,9 @@
 # CopyPolicy: Released under the terms of the GNU LGPL v2.0+
 
 cmake_minimum_required(VERSION 2.8.9)
+# Add cmake policy to resolve usage of <packagename>_ROOT
+# Reference: https://cmake.org/cmake/help/latest/policy/CMP0074.html#policy:CMP0074
+cmake_policy(SET CMP0074 NEW)
 project(forcetorque-yarp-devices)
 
 # Add local CMake files
@@ -15,7 +18,7 @@ include(YarpPlugin)
 include(YarpInstallationHelpers)
 set(YARP_FORCE_DYNAMIC_PLUGINS TRUE)
 
-# add_subdirectory(amti) # for the force plates, it needs to be checked if installing in a different machine is possible
+add_subdirectory(amti)
 add_subdirectory(optoforce)
 add_subdirectory(ATI_Ethernet)
 add_subdirectory(ftNode)

--- a/amti/CMakeLists.txt
+++ b/amti/CMakeLists.txt
@@ -6,8 +6,8 @@
 set(COMPILE_BY_DEFAULT ON)
 
 YARP_PREPARE_PLUGIN(amtiplatforms TYPE yarp::dev::AMTIPlatformsDriver
-                                  INCLUDE AMTIPlatformsDriver.h
-								  CATEGORY device)
+                                  INCLUDE include/AMTIPlatformsDriver.h
+				  CATEGORY device)
 
 if(ENABLE_amtiplatforms)
 
@@ -38,23 +38,27 @@ if(ENABLE_amtiplatforms)
 
     yarp_install(FILES amtiplatforms.ini  DESTINATION ${YARP_PLUGIN_MANIFESTS_INSTALL_DIR})
 
-	YARP_PREPARE_PLUGIN(amtiforceplate TYPE yarp::dev::AMTIForcePlate
-                                   INCLUDE AMTIForcePlate.h
-								   CATEGORY device
-								   EXTRA_CONFIG WRAPPER=AnalogServer)
+    YARP_PREPARE_PLUGIN(amtiforceplate TYPE yarp::dev::AMTIForcePlate
+                                       INCLUDE include/AMTIForcePlate.h
+			               CATEGORY device
+				       EXTRA_CONFIG WRAPPER=AnalogServer)
+    if(ENABLE_amtiforceplate)
 
-    yarp_add_plugin(amtiforceplate src/IMultipleForcePlates.cpp
-                                   src/AMTIForcePlate.cpp
-                                   include/IMultipleForcePlates.h
-                                   include/AMTIForcePlate.h)
+        yarp_add_plugin(amtiforceplate src/IMultipleForcePlates.cpp
+                                       src/AMTIForcePlate.cpp
+                                       include/IMultipleForcePlates.h
+                                       include/AMTIForcePlate.h)
 
-    target_link_libraries(amtiforceplate YARP::YARP_OS YARP::YARP_dev YARP::YARP_sig)
+        target_link_libraries(amtiforceplate YARP::YARP_OS YARP::YARP_dev YARP::YARP_sig)
 
-    yarp_install(TARGETS amtiforceplate
-                 COMPONENT runtime
-                 LIBRARY DESTINATION ${YARP_DYNAMIC_PLUGINS_INSTALL_DIR}
-                 ARCHIVE DESTINATION ${YARP_STATIC_PLUGINS_INSTALL_DIR})
+        yarp_install(TARGETS amtiforceplate
+                     COMPONENT runtime
+                     LIBRARY DESTINATION ${YARP_DYNAMIC_PLUGINS_INSTALL_DIR}
+                     ARCHIVE DESTINATION ${YARP_STATIC_PLUGINS_INSTALL_DIR})
 
-    yarp_install(FILES amtiforceplate.ini  DESTINATION ${YARP_PLUGIN_MANIFESTS_INSTALL_DIR})
+        yarp_install(FILES amtiforceplate.ini  DESTINATION ${YARP_PLUGIN_MANIFESTS_INSTALL_DIR})
+
+    endif()
+
 
 endif()

--- a/amti/include/IMultipleForcePlates.h
+++ b/amti/include/IMultipleForcePlates.h
@@ -8,22 +8,13 @@
 #define IMULTIPLEFORCEPLATES_H
 
 #include <string>
+#include <yarp/sig/Vector.h>
+#include <yarp/os/Stamp.h>
 
 namespace yarp {
 namespace dev {
     class IMultipleForcePlates;
 }
-
-namespace sig
-{
-    class Vector;
-}
-
-namespace os
-{
-    class Stamp;
-}
-
 }
 
 class yarp::dev::IMultipleForcePlates

--- a/amti/yarprobotinterface_amti.xml
+++ b/amti/yarprobotinterface_amti.xml
@@ -1,4 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE robot PUBLIC "-//YARP//DTD yarprobotinterface 3.0//EN" "http://www.yarp.it/DTD/yarprobotinterfaceV3.0.dtd">
 <robot name="forcePlates">
 
     <device type="amtiplatforms" name="FPplatform">


### PR DESCRIPTION
During recent tests on AMTI related code, I noticed some issues that this PR addresses, and the code was tested on a new Windows machine with [yarp-3.4](https://github.com/robotology/yarp/tree/yarp-3.4).  Guess this PR also addresses  https://github.com/robotology/forcetorque-yarp-devices/issues/14

CC @traversaro @claudia-lat @lrapetti 