### PR TITLE
Add rotation parameter for AMTIForcePlate device

### DIFF
--- a/amti/CMakeLists.txt
+++ b/amti/CMakeLists.txt
@@ -56,7 +56,7 @@ if(ENABLE_amtiplatforms)
         target_include_directories(amtiforceplate PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
                                                   SYSTEM PRIVATE ${EIGEN3_INCLUDE_DIR})
 
-        target_link_libraries(amtiforceplate YARP::YARP_OS YARP::YARP_dev YARP::YARP_sig iDynTree::idyntree-core iDynTree::idyntree-yarp)
+        target_link_libraries(amtiforceplate YARP::YARP_OS YARP::YARP_dev YARP::YARP_sig YARP::YARP_math)
 
         yarp_install(TARGETS amtiforceplate
                      COMPONENT runtime

--- a/amti/CMakeLists.txt
+++ b/amti/CMakeLists.txt
@@ -45,8 +45,6 @@ if(ENABLE_amtiplatforms)
     if(ENABLE_amtiforceplate)
 
         add_compile_definitions(_USE_MATH_DEFINES) #For using M_PI macro
-        find_package(iDynTree REQUIRED)
-        find_package(Eigen3 REQUIRED)
 
         yarp_add_plugin(amtiforceplate src/IMultipleForcePlates.cpp
                                        src/AMTIForcePlate.cpp

--- a/amti/CMakeLists.txt
+++ b/amti/CMakeLists.txt
@@ -44,6 +44,7 @@ if(ENABLE_amtiplatforms)
 								   EXTRA_CONFIG WRAPPER=AnalogServer)
     if(ENABLE_amtiforceplate)
 
+        add_compile_definitions(_USE_MATH_DEFINES) #For using M_PI macro
         find_package(iDynTree REQUIRED)
         find_package(Eigen3 REQUIRED)
 

--- a/amti/CMakeLists.txt
+++ b/amti/CMakeLists.txt
@@ -38,27 +38,33 @@ if(ENABLE_amtiplatforms)
 
     yarp_install(FILES amtiplatforms.ini  DESTINATION ${YARP_PLUGIN_MANIFESTS_INSTALL_DIR})
 
-    YARP_PREPARE_PLUGIN(amtiforceplate TYPE yarp::dev::AMTIForcePlate
-                                       INCLUDE include/AMTIForcePlate.h
-			               CATEGORY device
-				       EXTRA_CONFIG WRAPPER=AnalogServer)
+	YARP_PREPARE_PLUGIN(amtiforceplate TYPE yarp::dev::AMTIForcePlate
+                                   INCLUDE AMTIForcePlate.h
+								   CATEGORY device
+								   EXTRA_CONFIG WRAPPER=AnalogServer)
     if(ENABLE_amtiforceplate)
+
+        find_package(iDynTree REQUIRED)
+        find_package(Eigen3 REQUIRED)
 
         yarp_add_plugin(amtiforceplate src/IMultipleForcePlates.cpp
                                        src/AMTIForcePlate.cpp
                                        include/IMultipleForcePlates.h
                                        include/AMTIForcePlate.h)
 
-        target_link_libraries(amtiforceplate YARP::YARP_OS YARP::YARP_dev YARP::YARP_sig)
+        target_include_directories(amtiforceplate PUBLIC
+                                                  $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
+                                                  SYSTEM PRIVATE ${EIGEN3_INCLUDE_DIR})
+
+        target_link_libraries(amtiforceplate YARP::YARP_OS YARP::YARP_dev YARP::YARP_sig iDynTree::idyntree-core iDynTree::idyntree-yarp)
 
         yarp_install(TARGETS amtiforceplate
-                     COMPONENT runtime
-                     LIBRARY DESTINATION ${YARP_DYNAMIC_PLUGINS_INSTALL_DIR}
-                     ARCHIVE DESTINATION ${YARP_STATIC_PLUGINS_INSTALL_DIR})
+                    COMPONENT runtime
+                    LIBRARY DESTINATION ${YARP_DYNAMIC_PLUGINS_INSTALL_DIR}
+                    ARCHIVE DESTINATION ${YARP_STATIC_PLUGINS_INSTALL_DIR})
 
         yarp_install(FILES amtiforceplate.ini  DESTINATION ${YARP_PLUGIN_MANIFESTS_INSTALL_DIR})
 
     endif()
-
 
 endif()

--- a/amti/CMakeLists.txt
+++ b/amti/CMakeLists.txt
@@ -39,9 +39,9 @@ if(ENABLE_amtiplatforms)
     yarp_install(FILES amtiplatforms.ini  DESTINATION ${YARP_PLUGIN_MANIFESTS_INSTALL_DIR})
 
 	YARP_PREPARE_PLUGIN(amtiforceplate TYPE yarp::dev::AMTIForcePlate
-                                   INCLUDE AMTIForcePlate.h
-								   CATEGORY device
-								   EXTRA_CONFIG WRAPPER=AnalogServer)
+                                           INCLUDE AMTIForcePlate.h
+					   CATEGORY device
+				           EXTRA_CONFIG WRAPPER=AnalogServer)
     if(ENABLE_amtiforceplate)
 
         add_compile_definitions(_USE_MATH_DEFINES) #For using M_PI macro
@@ -53,16 +53,15 @@ if(ENABLE_amtiplatforms)
                                        include/IMultipleForcePlates.h
                                        include/AMTIForcePlate.h)
 
-        target_include_directories(amtiforceplate PUBLIC
-                                                  $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
+        target_include_directories(amtiforceplate PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
                                                   SYSTEM PRIVATE ${EIGEN3_INCLUDE_DIR})
 
         target_link_libraries(amtiforceplate YARP::YARP_OS YARP::YARP_dev YARP::YARP_sig iDynTree::idyntree-core iDynTree::idyntree-yarp)
 
         yarp_install(TARGETS amtiforceplate
-                    COMPONENT runtime
-                    LIBRARY DESTINATION ${YARP_DYNAMIC_PLUGINS_INSTALL_DIR}
-                    ARCHIVE DESTINATION ${YARP_STATIC_PLUGINS_INSTALL_DIR})
+                     COMPONENT runtime
+                     LIBRARY DESTINATION ${YARP_DYNAMIC_PLUGINS_INSTALL_DIR}
+                     ARCHIVE DESTINATION ${YARP_STATIC_PLUGINS_INSTALL_DIR})
 
         yarp_install(FILES amtiforceplate.ini  DESTINATION ${YARP_PLUGIN_MANIFESTS_INSTALL_DIR})
 

--- a/amti/include/AMTIForcePlate.h
+++ b/amti/include/AMTIForcePlate.h
@@ -11,6 +11,7 @@
 #include <yarp/dev/PreciselyTimed.h>
 #include <yarp/dev/IAnalogSensor.h>
 #include <yarp/dev/Wrapper.h>
+#include <yarp/sig/Matrix.h>
 #include <string>
 
 #include <iDynTree/Core/Transform.h>
@@ -40,7 +41,7 @@ class yarp::dev::AMTIForcePlate :
 
     // Platform rotation
     float m_rotation_angle; //Rotation about z axis
-    iDynTree::Transform m_transform;
+    yarp::sig::Matrix m_transform_wrench;
 
     // Buffers of sensor data and timestamp
     yarp::sig::Vector m_sensorReadings;

--- a/amti/include/AMTIForcePlate.h
+++ b/amti/include/AMTIForcePlate.h
@@ -12,6 +12,10 @@
 #include <yarp/dev/IAnalogSensor.h>
 #include <yarp/dev/Wrapper.h>
 #include <string>
+
+#include <iDynTree/Core/Transform.h>
+#include <iDynTree/Core/Rotation.h>
+
 namespace yarp {
     namespace dev {
         class AMTIForcePlate;
@@ -33,6 +37,10 @@ class yarp::dev::AMTIForcePlate :
 
     // Use a mutex to avoid race conditions
     yarp::os::Mutex m_mutex;
+
+    // Platform rotation
+    float m_rotation_angle; //Rotation about z axis
+    iDynTree::Transform m_transform;
 
     // Buffers of sensor data and timestamp
     yarp::sig::Vector m_sensorReadings;

--- a/amti/src/AMTIForcePlate.cpp
+++ b/amti/src/AMTIForcePlate.cpp
@@ -49,15 +49,18 @@ bool yarp::dev::AMTIForcePlate::open(yarp::os::Searchable &config)
     m_rotation_angle = 0.0;
     m_transform = iDynTree::Transform::Identity();
     iDynTree::Rotation rotz = iDynTree::Rotation::Identity();
-    if (!config.check("platformRotation") )
+
+    // Only z-axis rotation is considered as a configuration parameter
+    // Reference: Check fmSetPlatformRotation() from http://www.amti.jp/Gen%205%20Programmers%20Reference.pdf
+    if (!config.check("platformZRotation") )
     {
-        yWarning("<platformRotation> configuration parameter is not passed. Using default rotation 0 degree for platform %s", m_platformID);
+        yInfo("<platformZRotation> configuration parameter is not passed. Using default rotation 0 degree about z-axis for platform %s", m_platformID);
     }
     else
     {
-        m_rotation_angle = config.find("platformRotation").asFloat64();
+        m_rotation_angle = config.find("platformZRotation").asFloat64();
         rotz = iDynTree::Rotation::RotZ((m_rotation_angle/180) * M_PI);
-        yInfo("Using platform rotation of %f degree for platform %s", m_rotation_angle, m_platformID);
+        yInfo("Using platform rotation of %f degree about z-axis for platform %s", m_rotation_angle, m_platformID);
     }
 
     // Set transform with rotation

--- a/amti/yarprobotinterface_amti.xml
+++ b/amti/yarprobotinterface_amti.xml
@@ -3,25 +3,14 @@
 <robot name="forcePlates">
 
     <device type="amtiplatforms" name="FPplatform">
-		<param name="rate">100</param>
-		<param name="genlock">off</param>
-		<param name="dataFormat">data</param>
+	<param name="rate"> 100 </param>
+	<param name="genlock"> off </param>
+	<param name="dataFormat"> data </param>
     </device>
 	
     <device name="first_plaftform" type="amtiforceplate">
-        <param name="platformID">2897</param>
-		<param name="platformRotation">90</param>
-        <action phase="startup" level="5" type="attach">
-            <paramlist name="networks">
-                 <elem name="Platform">  FPplatform </elem>
-            </paramlist>
-        </action>
-
-        <action phase="shutdown" level="5" type="detach" />
-    </device>
-	<device name="second_plaftform" type="amtiforceplate">
-        <param name="platformID">2896</param>
-		<param name="platformRotation">270</param>
+        <param name="platformID"> 2897 </param>
+	<param name="platformRotation"> 90 </param>
         <action phase="startup" level="5" type="attach">
             <paramlist name="networks">
                  <elem name="Platform">  FPplatform </elem>
@@ -31,30 +20,37 @@
         <action phase="shutdown" level="5" type="detach" />
     </device>
 	
-	<device name="first_platform_wrapper" type="analogServer">
-		<param name="period">       10  				</param>
-		<param name="name">       /amti/first/analog:o		</param>
-		
-		<action phase="startup" level="10" type="attach">
-		    <paramlist name="networks">
-		        <elem name="FirstStrain">  first_plaftform </elem>
-		    </paramlist>
-		</action>
-
-		<action phase="shutdown" level="10" type="detach" />
-	</device>
+    <device name="second_plaftform" type="amtiforceplate">
+        <param name="platformID"> 2896 </param>
+	<param name="platformRotation"> 270 </param>
+        <action phase="startup" level="5" type="attach">
+            <paramlist name="networks">
+                 <elem name="Platform">  FPplatform </elem>
+            </paramlist>
+        </action>
+        <action phase="shutdown" level="5" type="detach" />
+    </device>
+	
+    <device name="first_platform_wrapper" type="analogServer">
+	<param name="period"> 10 </param>
+	<param name="name"> /amti/first/analog:o </param>
+	<action phase="startup" level="10" type="attach">
+	    <paramlist name="networks">
+		<elem name="FirstStrain">  first_plaftform </elem>
+	    </paramlist>
+	</action>
+	<action phase="shutdown" level="10" type="detach" />
+    </device>
 	
     <device name="second_platform_wrapper" type="analogServer">
-		<param name="period">       10  				</param>
-		<param name="name">       /amti/second/analog:o		</param>
-		
-		<action phase="startup" level="10" type="attach">
-		    <paramlist name="networks">
-		        <elem name="FirstStrain">  second_plaftform </elem>
-		    </paramlist>
-		</action>
-
-		<action phase="shutdown" level="10" type="detach" />
-	</device>
+	<param name="period"> 10 </param>
+	<param name="name"> /amti/second/analog:o </param>
+	<action phase="startup" level="10" type="attach">
+	    <paramlist name="networks">
+	        <elem name="FirstStrain">  second_plaftform </elem>
+	    </paramlist>
+	</action>
+	<action phase="shutdown" level="10" type="detach" />
+    </device>
   
 </robot> 

--- a/amti/yarprobotinterface_amti.xml
+++ b/amti/yarprobotinterface_amti.xml
@@ -10,7 +10,7 @@
 	
     <device name="first_plaftform" type="amtiforceplate">
         <param name="platformID">2897</param>
-        
+		<param name="platformRotation">90</param>
         <action phase="startup" level="5" type="attach">
             <paramlist name="networks">
                  <elem name="Platform">  FPplatform </elem>
@@ -21,7 +21,7 @@
     </device>
 	<device name="second_plaftform" type="amtiforceplate">
         <param name="platformID">2896</param>
-        
+		<param name="platformRotation">270</param>
         <action phase="startup" level="5" type="attach">
             <paramlist name="networks">
                  <elem name="Platform">  FPplatform </elem>

--- a/amti/yarprobotinterface_amti.xml
+++ b/amti/yarprobotinterface_amti.xml
@@ -10,7 +10,7 @@
 	
     <device name="first_plaftform" type="amtiforceplate">
         <param name="platformID"> 2897 </param>
-	<param name="platformRotation"> 90 </param>
+	<param name="platformZRotation"> 90 </param> <!-- Degree of rotation around z-axis -->
         <action phase="startup" level="5" type="attach">
             <paramlist name="networks">
                  <elem name="Platform">  FPplatform </elem>
@@ -22,7 +22,7 @@
 	
     <device name="second_plaftform" type="amtiforceplate">
         <param name="platformID"> 2896 </param>
-	<param name="platformRotation"> 270 </param>
+	<param name="platformZRotation"> 270 </param> <!-- Degree of rotation around z-axis -->
         <action phase="startup" level="5" type="attach">
             <paramlist name="networks">
                  <elem name="Platform">  FPplatform </elem>


### PR DESCRIPTION
After the AMTI force platforms are relocated, their new installation configuration in San Quirico is different from Morego, as shown below

![img_2743](https://user-images.githubusercontent.com/10923418/52274599-77c30180-294d-11e9-82aa-ea6f588c19d6.JPG)

This PR adds the option of a rotation about the z-axis to express the force torque values coming from the AMTI force platforms in the same frames as we had in Morego. 

I tested it by placing two `5 Kg` weights at the locations on the plates shown below

![1](https://user-images.githubusercontent.com/6505998/95841044-318a8c00-0d45-11eb-9a85-a4edb0ad302f.jpg)

Using the reference of the frames from above

![Screenshot 2020-10-12 192012](https://user-images.githubusercontent.com/6505998/95841416-a231a880-0d45-11eb-97d8-a784d405aa5b.png)

Input wrench is in the frames of the san quirico figure, and output wrench is in the frames of the old morego configuration. 

CC @claudia-lat @lrapetti @DanielePucci 