### PR TITLE
Fix plugins installation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -26,6 +26,9 @@ else()
  option(BUILD_SHARED_LIBS "Build libraries as shared as opposed to static" ON)
 endif()
 
+# Warning: the <package> option of yarp_configure_plugins_installation should be different from the plugin names
+yarp_configure_plugins_installation(forcetorque_devices_lookup)
+
 add_subdirectory(amti)
 add_subdirectory(optoforce)
 add_subdirectory(ATI_Ethernet)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,13 +19,6 @@ include(YarpInstallationHelpers)
 
 set(YARP_FORCE_DYNAMIC_PLUGINS TRUE)
 
-# Libraries type
-if(MSVC)
- option(BUILD_SHARED_LIBS "Build libraries as shared as opposed to static" OFF)
-else()
- option(BUILD_SHARED_LIBS "Build libraries as shared as opposed to static" ON)
-endif()
-
 # Warning: the <package> option of yarp_configure_plugins_installation should be different from the plugin names
 yarp_configure_plugins_installation(forcetorque_devices_lookup)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,7 +16,15 @@ find_package(YARP REQUIRED)
 list(APPEND CMAKE_MODULE_PATH ${YARP_MODULE_PATH})
 include(YarpPlugin)
 include(YarpInstallationHelpers)
+
 set(YARP_FORCE_DYNAMIC_PLUGINS TRUE)
+
+# Libraries type
+if(MSVC)
+ option(BUILD_SHARED_LIBS "Build libraries as shared as opposed to static" OFF)
+else()
+ option(BUILD_SHARED_LIBS "Build libraries as shared as opposed to static" ON)
+endif()
 
 add_subdirectory(amti)
 add_subdirectory(optoforce)

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ The repo contains the following YARP devices :
 * Compile the code in this repository using [CMake](https://cmake.org/) and your preferred compiler. See [YARP documentation on how to compile a CMake project](http://www.yarp.it/using_cmake.html).
 * Note that by default all devices are active. Deactivate the device you don't want to compile.
 * Install the compiled devices. You can specify the installation directory using the [`CMAKE_INSTALL_PREFIX`](https://cmake.org/cmake/help/v3.0/variable/CMAKE_INSTALL_PREFIX.html) CMake option.
-* Add `${CMAKE_INSTALL_PREFIX}/share/forcetorque-yarp-devices` (where `${CMAKE_INSTALL_PREFIX}` needs to be substituted to the directory that you choose as the `CMAKE_INSTALL_PREFIX`) to your `YARP_DATA_DIRS` enviromental variable (for more on the `YARP_DATA_DIRS` env variable, see [YARP documentation on data directories](http://www.yarp.it/yarp_data_dirs.html) ). 
+* Add `${CMAKE_INSTALL_PREFIX}/share/yarp` (where `${CMAKE_INSTALL_PREFIX}` needs to be substituted to the directory that you choose as the `CMAKE_INSTALL_PREFIX`) to your `YARP_DATA_DIRS` enviromental variable (for more on the `YARP_DATA_DIRS` env variable, see [YARP documentation on data directories](http://www.yarp.it/yarp_data_dirs.html) ). 
 * Once you do that, you should be able to find the devices compiled by this repo (for example the `forcetorqueDriverExample`) using the command `yarp plugin forcetorqueDriverExample`, which should have an output similar to:
 ~~~
 Yes, this is a YARP plugin

--- a/amti/CMakeLists.txt
+++ b/amti/CMakeLists.txt
@@ -11,6 +11,9 @@ YARP_PREPARE_PLUGIN(amtiplatforms TYPE yarp::dev::AMTIPlatformsDriver
 
 if(ENABLE_amtiplatforms)
 
+    # Warning: the <package> option of yarp_configure_plugins_installation should be different from the plugin name
+    yarp_configure_plugins_installation(amti_devices_lookup)
+
     find_package(AMTIDriver REQUIRED)
 
     if (CMAKE_VERSION VERSION_LESS "3.1")

--- a/amti/CMakeLists.txt
+++ b/amti/CMakeLists.txt
@@ -11,9 +11,6 @@ YARP_PREPARE_PLUGIN(amtiplatforms TYPE yarp::dev::AMTIPlatformsDriver
 
 if(ENABLE_amtiplatforms)
 
-    # Warning: the <package> option of yarp_configure_plugins_installation should be different from the plugin name
-    yarp_configure_plugins_installation(amti_devices_lookup)
-
     find_package(AMTIDriver REQUIRED)
 
     if (CMAKE_VERSION VERSION_LESS "3.1")


### PR DESCRIPTION
This PR addresses the installation of the ~AMTI platforms~ devices when the repository is not installed via the robotology-superbuild.

In such case, these related yarp devices cannot be loaded since the DLLs cannot be found (if not manually pointed to from some environment variables).
In order to solve this, a `.ini` file is added in the installation process, which allows the lookup of such DLLs.
~To correctly generate such file, the `BUILD_SHARED_LIBS` is set by default to `TRUE` when using MSVC.~

In this context, the README of the repo has been updated to fix a wrong path to be added to `YARP_DATA_DIRS`. 