### PR TITLE
Remove calls to YARP deprecated methods

### DIFF
--- a/amti/src/AMTIPlatformsDriver.cpp
+++ b/amti/src/AMTIPlatformsDriver.cpp
@@ -86,9 +86,9 @@ bool yarp::dev::AMTIPlatformsDriver::open(yarp::os::Searchable &config)
         return false;
     }
 
-    int periodInMilliseconds = config.check("period", yarp::os::Value(10), "period of the data-reading thread (ms)").asInt();
+    int periodInMilliseconds = config.check("period", yarp::os::Value(10), "period of the data-reading thread (ms)").asInt32();
 
-    double readingTimeout = config.check("timeout", yarp::os::Value(0.5), "number of seconds before timeout error (s)").asDouble();
+    double readingTimeout = config.check("timeout", yarp::os::Value(0.5), "number of seconds before timeout error (s)").asFloat64();
 
     std::string genLock = config.check("genlock", yarp::os::Value("off"), "genlock mode (off|raise|fall)").asString();
     AMTI_GENLOCK genlockOption = AMTI_GENLOCK_OFF;

--- a/ftNode/ftnodeDriver.cpp
+++ b/ftNode/ftnodeDriver.cpp
@@ -119,7 +119,7 @@ bool ftnodeDriver::open(yarp::os::Searchable& config)
     // Parse the configuration parameters
     // ==================================
 
-    pImpl->numberOfFTSensors = config.find("numberOfFTSensors").asInt();
+    pImpl->numberOfFTSensors = config.find("numberOfFTSensors").asInt32();
 
     // Initialize the serial port data buffers vector
     pImpl->serialPortWrenchDataVector.resize(pImpl->numberOfFTSensors);
@@ -153,7 +153,7 @@ bool ftnodeDriver::open(yarp::os::Searchable& config)
 
         std::vector<double> wrenchScalingFactorVec(6, 0.0);
         for (size_t s = 0; s < wrenchScalingFactorList->size(); s++) {
-            wrenchScalingFactorVec.at(s) = wrenchScalingFactorList->get(s).asDouble();
+            wrenchScalingFactorVec.at(s) = wrenchScalingFactorList->get(s).asFloat64();
         }
 
         pImpl->wrenchScalingFactors.at(i-1) = wrenchScalingFactorVec;

--- a/ftShoe/ftshoeDriver.cpp
+++ b/ftShoe/ftshoeDriver.cpp
@@ -97,8 +97,8 @@ bool yarp::dev::ftshoeDriver::open(yarp::os::Searchable &config)
 
         // Get the first sensor range
         yarp::os::Bottle *firstSensorRange = config.find("ftNodeFirstSensorRange").asList();
-        ftNode_firstSensorRange[0] = firstSensorRange->get(0).asInt();
-        ftNode_firstSensorRange[1] = firstSensorRange->get(1).asInt();
+        ftNode_firstSensorRange[0] = firstSensorRange->get(0).asInt32();
+        ftNode_firstSensorRange[1] = firstSensorRange->get(1).asInt32();
 
         if (ftNode_firstSensorRange[0] > ftNode_firstSensorRange[1]) {
             yError() << "ftshoeDriver : ftNodeFirstSensorRange first value should be less than the second number";
@@ -107,8 +107,8 @@ bool yarp::dev::ftshoeDriver::open(yarp::os::Searchable &config)
 
         // Get the second sensor range
         yarp::os::Bottle *secondSensorRange = config.find("ftNodeSecondSensorRange").asList();
-        ftNode_secondSensorRange[0] = secondSensorRange->get(0).asInt();
-        ftNode_secondSensorRange[1] = secondSensorRange->get(1).asInt();
+        ftNode_secondSensorRange[0] = secondSensorRange->get(0).asInt32();
+        ftNode_secondSensorRange[1] = secondSensorRange->get(1).asInt32();
 
         if (ftNode_secondSensorRange[0] > ftNode_secondSensorRange[1]) {
             yError() << "ftshoeDriver : ftNodeSecondSenorRange first value should be less than the second number";
@@ -124,7 +124,7 @@ bool yarp::dev::ftshoeDriver::open(yarp::os::Searchable &config)
     {
         for (int i = 0; i < 3; ++i)
         {
-            fts_offset(i) = prop.find("fts_offset").asList()->get(i).asDouble();
+            fts_offset(i) = prop.find("fts_offset").asList()->get(i).asFloat64();
         }
     }
     else
@@ -147,7 +147,7 @@ bool yarp::dev::ftshoeDriver::open(yarp::os::Searchable &config)
                 for (int c = 0; c < 3; c++)
                 {
                     int rowMajorIndex = 3 * r + c;
-                    fts_orientation_R(r, c) = prop.find("fts_orientation_R").asList()->get(rowMajorIndex).asDouble();
+                    fts_orientation_R(r, c) = prop.find("fts_orientation_R").asList()->get(rowMajorIndex).asFloat64();
                 }
             }
         }
@@ -172,7 +172,7 @@ bool yarp::dev::ftshoeDriver::open(yarp::os::Searchable &config)
                 for (int c = 0; c < 3; c++)
                 {
                     int rowMajorIndex = 3 * r + c;
-                    s_fts_to_out_R(r, c) = prop.find("rear_fts_to_out_R").asList()->get(rowMajorIndex).asDouble();
+                    s_fts_to_out_R(r, c) = prop.find("rear_fts_to_out_R").asList()->get(rowMajorIndex).asFloat64();
                 }
             }
         }
@@ -220,8 +220,8 @@ bool yarp::dev::ftshoeDriver::open(yarp::os::Searchable &config)
                     for (int c = 0; c < 6; c++)
                     {
                         int rowMajorIndex = 6 * r + c;
-                        f_insitu_matrix(r, c) = group.find("front_fts").asList()->get(rowMajorIndex).asDouble();
-                        s_insitu_matrix(r, c) = group.find("rear_fts").asList()->get(rowMajorIndex).asDouble();
+                        f_insitu_matrix(r, c) = group.find("front_fts").asList()->get(rowMajorIndex).asFloat64();
+                        s_insitu_matrix(r, c) = group.find("rear_fts").asList()->get(rowMajorIndex).asFloat64();
                     }
                 }
             }

--- a/ftShoeUdpWrapper/ftShoeUdpWrapper.cpp
+++ b/ftShoeUdpWrapper/ftShoeUdpWrapper.cpp
@@ -76,8 +76,8 @@ bool ftShoeUdpWrapper::open(yarp::os::Searchable& config)
     }
 
     m_address = prop.find("endpointAddress").asString();
-    m_port = static_cast<unsigned>(prop.find("udpPort").asInt());
-    const int threadPeriod = prop.find("threadPeriod").asInt();
+    m_port = static_cast<unsigned>(prop.find("udpPort").asInt32());
+    const int threadPeriod = prop.find("threadPeriod").asInt32();
 
     if (!setRate(threadPeriod)) {
         yError() << logPrefix + "Failed to set specified thread period";

--- a/optoforce/optoforceDriver.cpp
+++ b/optoforce/optoforceDriver.cpp
@@ -77,21 +77,21 @@ bool yarp::dev::optoforceDriver::open(yarp::os::Searchable &config)
 
     //store calibration
 
-        //prop.findGroup("Fx").tail().get(0).asDouble()/prop.findGroup("Fx").tail().get(0).asDouble()
+        //prop.findGroup("Fx").tail().get(0).asFloat64()/prop.findGroup("Fx").tail().get(0).asFloat64()
 //    double  test;
-//       test=prop.findGroup("Fx").tail().get(0).asDouble()/prop.findGroup("Fx").tail().get(1).asDouble();
+//       test=prop.findGroup("Fx").tail().get(0).asFloat64()/prop.findGroup("Fx").tail().get(1).asFloat64();
 //        std::ostringstream os;
 //        os << test;
 //        std::string str = os.str();
 //        yInfo(str);
-         calibFactor[0] = prop.findGroup("Fx").tail().get(0).asDouble()/prop.findGroup("Fx").tail().get(1).asDouble();
-      calibFactor[1] = prop.findGroup("Fy").tail().get(0).asDouble()/prop.findGroup("Fy").tail().get(1).asDouble();
-     calibFactor[2] = prop.findGroup("Fz").tail().get(0).asDouble()/prop.findGroup("Fz").tail().get(1).asDouble();
+         calibFactor[0] = prop.findGroup("Fx").tail().get(0).asFloat64()/prop.findGroup("Fx").tail().get(1).asFloat64();
+      calibFactor[1] = prop.findGroup("Fy").tail().get(0).asFloat64()/prop.findGroup("Fy").tail().get(1).asFloat64();
+     calibFactor[2] = prop.findGroup("Fz").tail().get(0).asFloat64()/prop.findGroup("Fz").tail().get(1).asFloat64();
 
      // Set torque on x,y,z axis
-     calibFactor[3] = prop.findGroup("Tx").tail().get(0).asDouble()/prop.findGroup("Tx").tail().get(1).asDouble();
-     calibFactor[4] = prop.findGroup("Ty").tail().get(0).asDouble()/prop.findGroup("Ty").tail().get(1).asDouble();
-     calibFactor[5] = prop.findGroup("Tz").tail().get(0).asDouble()/prop.findGroup("Tz").tail().get(1).asDouble();
+     calibFactor[3] = prop.findGroup("Tx").tail().get(0).asFloat64()/prop.findGroup("Tx").tail().get(1).asFloat64();
+     calibFactor[4] = prop.findGroup("Ty").tail().get(0).asFloat64()/prop.findGroup("Ty").tail().get(1).asFloat64();
+     calibFactor[5] = prop.findGroup("Tz").tail().get(0).asFloat64()/prop.findGroup("Tz").tail().get(1).asFloat64();
   // config should be parsed for the options of the device
   return true;
 }


### PR DESCRIPTION
As per https://github.com/robotology/forcetorque-yarp-devices/issues/28.