### PR TITLE
Fix compatibility with YARP 3.7

### DIFF
--- a/ftNode/ftnodeDriver.cpp
+++ b/ftNode/ftnodeDriver.cpp
@@ -82,7 +82,7 @@ bool ftnodeDriver::open(yarp::os::Searchable& config)
     // The number of sensors to be configured for IAnalogSensor interface
     // Currently, the serial port streams data from only one FT and in the
     // future it will also stream the data from the four FTs of the FTshoes
-    if (!(config.check("numberOfFTSensors") && config.find("numberOfFTSensors").isInt())) {
+    if (!(config.check("numberOfFTSensors") && config.find("numberOfFTSensors").isInt32())) {
         yError() << LogPrefix << "Option 'channels' not found or not a valid integer";
         return false;
     }

--- a/ftShoeUdpWrapper/ftShoeUdpWrapper.cpp
+++ b/ftShoeUdpWrapper/ftShoeUdpWrapper.cpp
@@ -64,12 +64,12 @@ bool ftShoeUdpWrapper::open(yarp::os::Searchable& config)
         return false;
     }
 
-    if (!(prop.check("udpPort") && prop.find("udpPort").isInt())) {
+    if (!(prop.check("udpPort") && prop.find("udpPort").isInt32())) {
         yError() << logPrefix + "UDP Port parameter missing or invalid in the configuration file";
         return false;
     }
 
-    if (!(prop.check("threadPeriod") && prop.find("threadPeriod").isInt())) {
+    if (!(prop.check("threadPeriod") && prop.find("threadPeriod").isInt32())) {
         yError() << logPrefix
                         + "Thread period parameter missing or invalid in the configuration file";
         return false;


### PR DESCRIPTION
There were a few methods missed by https://github.com/robotology/forcetorque-yarp-devices/pull/29 .